### PR TITLE
registry: add a registry controller for listing the registries

### DIFF
--- a/pkg/registry/options.go
+++ b/pkg/registry/options.go
@@ -1,0 +1,25 @@
+package registry
+
+import (
+	"github.com/tilt-dev/ctlptl/pkg/api"
+	"k8s.io/apimachinery/pkg/fields"
+)
+
+type ListOptions struct {
+	FieldSelector string
+}
+
+type registryFields api.Registry
+
+func (cf *registryFields) Has(field string) bool {
+	return field == "name"
+}
+
+func (cf *registryFields) Get(field string) string {
+	if field == "name" {
+		return (*api.Registry)(cf).Name
+	}
+	return ""
+}
+
+var _ fields.Fields = &registryFields{}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,0 +1,131 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/tilt-dev/ctlptl/pkg/api"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var typeMeta = api.TypeMeta{APIVersion: "ctlptl.dev/v1alpha1", Kind: "Registry"}
+var groupResource = schema.GroupResource{"ctlptl.dev", "registries"}
+
+type ContainerClient interface {
+	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
+}
+
+type Controller struct {
+	dockerClient ContainerClient
+}
+
+func NewController(dockerClient ContainerClient) (*Controller, error) {
+	return &Controller{
+		dockerClient: dockerClient,
+	}, nil
+}
+
+func DefaultController(ctx context.Context) (*Controller, error) {
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return nil, err
+	}
+
+	dockerClient.NegotiateAPIVersion(ctx)
+
+	return NewController(dockerClient)
+}
+
+func (c *Controller) Apply(ctx context.Context, registry *api.Registry) (*api.Registry, error) {
+	fmt.Printf("Registry Apply is currently a stub! You applied:\n%+v\n", registry)
+	return registry, nil
+}
+
+func (c *Controller) Get(ctx context.Context, name string) (*api.Registry, error) {
+	registries, err := c.List(ctx, ListOptions{FieldSelector: fmt.Sprintf("name=%s", name)})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(registries) == 0 {
+		return nil, errors.NewNotFound(groupResource, name)
+	}
+
+	return registries[0], nil
+}
+
+func (c *Controller) List(ctx context.Context, options ListOptions) ([]*api.Registry, error) {
+	selector, err := fields.ParseSelector(options.FieldSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	filterArgs := filters.NewArgs()
+	filterArgs.Add("ancestor", "registry:2") // The registry everyone uses.
+
+	containers, err := c.dockerClient.ContainerList(ctx, types.ContainerListOptions{
+		Filters: filterArgs,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result := []*api.Registry{}
+	for _, container := range containers {
+		if len(container.Names) == 0 {
+			continue
+		}
+		name := strings.TrimPrefix(container.Names[0], "/")
+		created := time.Unix(container.Created, 0)
+
+		netSummary := container.NetworkSettings
+		ipAddress := ""
+		if netSummary != nil {
+			bridge, ok := netSummary.Networks["bridge"]
+			if ok && bridge != nil {
+				ipAddress = bridge.IPAddress
+			}
+		}
+
+		hostPort, containerPort := c.portsFrom(container.Ports)
+
+		registry := &api.Registry{
+			TypeMeta: typeMeta,
+			Name:     name,
+			Status: api.RegistryStatus{
+				CreationTimestamp: metav1.Time{Time: created},
+				IPAddress:         ipAddress,
+				HostPort:          hostPort,
+				ContainerPort:     containerPort,
+			},
+		}
+
+		if !selector.Matches((*registryFields)(registry)) {
+			continue
+		}
+		result = append(result, registry)
+	}
+	return result, nil
+}
+
+func (c *Controller) portsFrom(ports []types.Port) (hostPort int, containerPort int) {
+	for _, port := range ports {
+		if port.IP != "0.0.0.0" {
+			continue
+		}
+		if port.PublicPort == 0 {
+			continue
+		}
+
+		return int(port.PublicPort), int(port.PrivatePort)
+	}
+	return 0, 0
+}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,0 +1,106 @@
+package registry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
+	"github.com/stretchr/testify/require"
+	"github.com/tilt-dev/ctlptl/pkg/api"
+	"gotest.tools/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var kindRegistry = types.Container{
+	ID:      "a815c0ec15f1f7430bd402e3fffe65026dd692a1a99861a52b3e30ad6e253a08",
+	Names:   []string{"/kind-registry"},
+	Image:   "registry:2",
+	ImageID: "sha256:2d4f4b5309b1e41b4f83ae59b44df6d673ef44433c734b14c1c103ebca82c116",
+	Command: "/entrypoint.sh /etc/docker/registry/config.yml",
+	Created: 1603483645,
+	Ports: []types.Port{
+		types.Port{IP: "0.0.0.0", PrivatePort: 5000, PublicPort: 5001, Type: "tcp"},
+	},
+	SizeRw:     0,
+	SizeRootFs: 0,
+	State:      "running",
+	Status:     "Up 2 hours",
+	NetworkSettings: &types.SummaryNetworkSettings{
+		Networks: map[string]*network.EndpointSettings{
+			"bridge": &network.EndpointSettings{
+				IPAddress: "172.0.1.2",
+			},
+		},
+	},
+}
+
+func TestListRegistries(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.docker.containers = []types.Container{kindRegistry}
+
+	registries, err := f.c.List(context.Background(), ListOptions{})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(registries))
+	assert.Equal(t, *registries[0], api.Registry{
+		TypeMeta: typeMeta,
+		Name:     "kind-registry",
+		Status: api.RegistryStatus{
+			CreationTimestamp: metav1.Time{Time: time.Unix(1603483645, 0)},
+			HostPort:          5001,
+			ContainerPort:     5000,
+			IPAddress:         "172.0.1.2",
+		},
+	})
+}
+
+func TestGetRegistry(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	f.docker.containers = []types.Container{kindRegistry}
+
+	registry, err := f.c.Get(context.Background(), "kind-registry")
+	require.NoError(t, err)
+	assert.Equal(t, *registry, api.Registry{
+		TypeMeta: typeMeta,
+		Name:     "kind-registry",
+		Status: api.RegistryStatus{
+			CreationTimestamp: metav1.Time{Time: time.Unix(1603483645, 0)},
+			HostPort:          5001,
+			ContainerPort:     5000,
+			IPAddress:         "172.0.1.2",
+		},
+	})
+}
+
+type fakeDocker struct {
+	containers []types.Container
+}
+
+func (d *fakeDocker) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+	return d.containers, nil
+}
+
+type fixture struct {
+	t      *testing.T
+	c      *Controller
+	docker *fakeDocker
+}
+
+func newFixture(t *testing.T) *fixture {
+	d := &fakeDocker{}
+	controller, err := NewController(d)
+	require.NoError(t, err)
+	return &fixture{
+		t:      t,
+		docker: d,
+		c:      controller,
+	}
+}
+
+func (fixture) TearDown() {}


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/registry:

908e74cf62125f05ee15b55e76ce78701a95bf7e (2020-10-23 18:50:30 -0400)
registry: add a registry controller for listing the registries

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics