### PR TITLE
cluster: support deletion of a docker-desktop-based cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: generate test vendor
 
+install:
+	go install ./cmd/ctlptl
+
 test:
 	go test -timeout 30s -v ./...
 

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -266,6 +266,7 @@ type fakeD4MClient struct {
 	docker             *fakeDockerClient
 	started            bool
 	settingsWriteCount int
+	resetCount         int
 }
 
 func (c *fakeD4MClient) writeSettings(ctx context.Context, settings map[string]interface{}) error {
@@ -279,7 +280,7 @@ func (c *fakeD4MClient) settings(ctx context.Context) (map[string]interface{}, e
 	return c.lastSettings, nil
 }
 
-func (c *fakeD4MClient) ensureK8sEnabled(settings map[string]interface{}) (bool, error) {
+func (c *fakeD4MClient) setK8sEnabled(settings map[string]interface{}, desired bool) (bool, error) {
 	enabled, ok := settings["k8sEnabled"]
 	if ok && enabled.(bool) == true {
 		return false, nil
@@ -296,6 +297,11 @@ func (c *fakeD4MClient) ensureMinCPU(settings map[string]interface{}, desired in
 	settings["cpu"] = desired
 	return true, nil
 
+}
+
+func (c *fakeD4MClient) resetK8s(ctx context.Context) error {
+	c.resetCount++
+	return nil
 }
 
 func (c *fakeD4MClient) start(ctx context.Context) error {

--- a/pkg/cluster/docker_for_mac_test.go
+++ b/pkg/cluster/docker_for_mac_test.go
@@ -36,7 +36,7 @@ func TestEnableKubernetes(t *testing.T) {
 	settings, err := f.d4m.settings(ctx)
 	require.NoError(t, err)
 
-	changed, err := f.d4m.ensureK8sEnabled(settings)
+	changed, err := f.d4m.setK8sEnabled(settings, true)
 	assert.True(t, changed)
 	require.NoError(t, err)
 

--- a/pkg/cluster/machine.go
+++ b/pkg/cluster/machine.go
@@ -47,7 +47,8 @@ type sleeper func(dur time.Duration)
 type d4mClient interface {
 	writeSettings(ctx context.Context, settings map[string]interface{}) error
 	settings(ctx context.Context) (map[string]interface{}, error)
-	ensureK8sEnabled(settings map[string]interface{}) (bool, error)
+	resetK8s(tx context.Context) error
+	setK8sEnabled(settings map[string]interface{}, desired bool) (bool, error)
 	ensureMinCPU(settings map[string]interface{}, desired int) (bool, error)
 	start(ctx context.Context) error
 }
@@ -142,7 +143,7 @@ func (m dockerMachine) Restart(ctx context.Context, desired, existing *api.Clust
 
 		k8sChanged := false
 		if desired.Product == string(ProductDockerDesktop) {
-			k8sChanged, err = m.d4m.ensureK8sEnabled(settings)
+			k8sChanged, err = m.d4m.setK8sEnabled(settings, true)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/d4m-delete:

3d029d3e7ba28b4848c098fc28f60873feeaef58 (2020-11-04 17:03:35 -0500)
cluster: support deletion of a docker-desktop-based cluster

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics