### PR TITLE
hide klog flags from the help output

### DIFF
--- a/cmd/ctlptl/main.go
+++ b/cmd/ctlptl/main.go
@@ -22,7 +22,11 @@ func main() {
 	command.AddCommand(newVersionCommand())
 
 	klog.InitFlags(nil)
+
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.VisitAll(func(f *pflag.Flag) {
+		f.Hidden = true
+	})
 
 	if err := command.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/flags:

0b3efcd040cc6ebb2939f5a3030fa3e06702bf21 (2020-11-05 21:51:38 -0500)
hide klog flags from the help output

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics