### PR TITLE
cluster: print current cluster, like kubectl config get-contexts

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -53,6 +53,9 @@ type ClusterStatus struct {
 
 	// The number of CPU. Only applicable to local clusters.
 	CPUs int `json:"cpus,omitempty" yaml:"cpus,omitempty"`
+
+	// Whether this is the current cluster in `kubectl`
+	Current bool `json:"current,omitempty" yaml:"current,omitempty"`
 }
 
 // ClusterList is a list of Clusters.

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -170,6 +170,13 @@ func (c *Controller) configCopy() *clientcmdapi.Config {
 	return c.config.DeepCopy()
 }
 
+func (c *Controller) configCurrent() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.config.CurrentContext
+}
+
 func (c *Controller) client(name string) (kubernetes.Interface, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -303,6 +310,8 @@ func (c *Controller) populateCluster(ctx context.Context, cluster *api.Cluster) 
 	}()
 
 	wg.Wait()
+
+	cluster.Status.Current = c.configCurrent() == cluster.Name
 }
 
 func FillDefaults(cluster *api.Cluster) {

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -181,6 +181,10 @@ func (o *GetOptions) clustersAsTable(clusters []api.Cluster) runtime.Object {
 		TypeMeta: metav1.TypeMeta{Kind: "Table", APIVersion: "metav1.k8s.io"},
 		ColumnDefinitions: []metav1.TableColumnDefinition{
 			metav1.TableColumnDefinition{
+				Name: "Current",
+				Type: "string",
+			},
+			metav1.TableColumnDefinition{
 				Name: "Name",
 				Type: "string",
 			},
@@ -214,8 +218,14 @@ func (o *GetOptions) clustersAsTable(clusters []api.Cluster) runtime.Object {
 			rHost = "none"
 		}
 
+		current := ""
+		if cluster.Status.Current {
+			current = "*"
+		}
+
 		table.Rows = append(table.Rows, metav1.TableRow{
 			Cells: []interface{}{
+				current,
 				cluster.Name,
 				cluster.Product,
 				age,

--- a/pkg/cmd/get_test.go
+++ b/pkg/cmd/get_test.go
@@ -25,6 +25,7 @@ var clusterList = &api.ClusterList{
 			Product:  "microk8s",
 			Status: api.ClusterStatus{
 				CreationTimestamp: metav1.Time{Time: createTime},
+				Current:           true,
 			},
 		},
 		api.Cluster{
@@ -49,9 +50,9 @@ func TestDefaultPrint(t *testing.T) {
 
 	err := o.Print(o.transformForOutput(clusterList))
 	require.NoError(t, err)
-	assert.Equal(t, out.String(), `NAME        PRODUCT    AGE   REGISTRY
-microk8s    microk8s   3y    none
-kind-kind   KIND       3y    localhost:5000
+	assert.Equal(t, out.String(), `CURRENT   NAME        PRODUCT    AGE   REGISTRY
+*         microk8s    microk8s   3y    none
+          kind-kind   KIND       3y    localhost:5000
 `)
 }
 
@@ -73,6 +74,7 @@ items:
   product: microk8s
   status:
     creationTimestamp: "2017-07-14T02:40:00Z"
+    current: true
 - apiVersion: ctlptl.dev/v1alpha1
   kind: Cluster
   name: kind-kind


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/current:

7ae93eaf468c9f0485f5dd67a02a3dbe2fbea049 (2020-11-09 13:03:42 -0500)
cluster: print current cluster, like kubectl config get-contexts

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics