### PR TITLE
cmd: add a docker-desktop reset-cluster command

### DIFF
--- a/pkg/cluster/admin_docker_desktop.go
+++ b/pkg/cluster/admin_docker_desktop.go
@@ -46,7 +46,7 @@ func (a *dockerDesktopAdmin) Delete(ctx context.Context, config *api.Cluster) er
 		return err
 	}
 
-	err = client.resetK8s(ctx)
+	err = client.ResetCluster(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -359,7 +359,7 @@ func (c *fakeD4MClient) ensureMinCPU(settings map[string]interface{}, desired in
 
 }
 
-func (c *fakeD4MClient) resetK8s(ctx context.Context) error {
+func (c *fakeD4MClient) ResetCluster(ctx context.Context) error {
 	c.resetCount++
 	return nil
 }

--- a/pkg/cluster/docker_desktop.go
+++ b/pkg/cluster/docker_desktop.go
@@ -70,7 +70,7 @@ func (c DockerDesktopClient) start(ctx context.Context) error {
 	return err
 }
 
-func (c DockerDesktopClient) resetK8s(ctx context.Context) error {
+func (c DockerDesktopClient) ResetCluster(ctx context.Context) error {
 	klog.V(7).Infof("POST %s /kubernetes/reset\n", c.socketPath)
 	req, err := http.NewRequest("POST", "http://localhost/kubernetes/reset", nil)
 	if err != nil {

--- a/pkg/cluster/machine.go
+++ b/pkg/cluster/machine.go
@@ -47,7 +47,7 @@ type sleeper func(dur time.Duration)
 type d4mClient interface {
 	writeSettings(ctx context.Context, settings map[string]interface{}) error
 	settings(ctx context.Context) (map[string]interface{}, error)
-	resetK8s(tx context.Context) error
+	ResetCluster(tx context.Context) error
 	setK8sEnabled(settings map[string]interface{}, desired bool) (bool, error)
 	ensureMinCPU(settings map[string]interface{}, desired int) (bool, error)
 	start(ctx context.Context) error

--- a/pkg/cmd/docker_desktop.go
+++ b/pkg/cmd/docker_desktop.go
@@ -26,6 +26,14 @@ func NewDockerDesktopCommand() *cobra.Command {
 		Run:   withDockerDesktopClient("docker-desktop-settings", dockerDesktopSettings),
 		Args:  cobra.ExactArgs(0),
 	})
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "reset-cluster",
+		Short: "Reset the docker-desktop Kubernetes cluster",
+		Run:   withDockerDesktopClient("docker-desktop-reset-cluster", dockerDesktopResetCluster),
+		Args:  cobra.ExactArgs(0),
+	})
+
 	cmd.AddCommand(&cobra.Command{
 		Use:   "set KEY VALUE",
 		Short: "Set the docker-desktop settings",
@@ -83,4 +91,8 @@ func dockerDesktopSettings(c cluster.DockerDesktopClient, args []string) error {
 
 func dockerDesktopSet(c cluster.DockerDesktopClient, args []string) error {
 	return c.SetSettingValue(context.Background(), args[0], args[1])
+}
+
+func dockerDesktopResetCluster(c cluster.DockerDesktopClient, args []string) error {
+	return c.ResetCluster(context.Background())
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/reset:

d5f48190a59fa0dcf935ab9c7e200f1f059af205 (2020-11-13 13:28:37 -0500)
cmd: add a docker-desktop reset-cluster command

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics