### PR TITLE
cluster: minikube 1.15 creates a unique network for each cluster

### DIFF
--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -321,6 +321,10 @@ func (c *fakeDockerClient) Info(ctx context.Context) (types.Info, error) {
 	return types.Info{NCPU: c.ncpu}, nil
 }
 
+func (c *fakeDockerClient) ContainerInspect(ctx context.Context, id string) (types.ContainerJSON, error) {
+	return types.ContainerJSON{}, nil
+}
+
 type fakeD4MClient struct {
 	lastSettings       map[string]interface{}
 	docker             *fakeDockerClient

--- a/pkg/cluster/docker.go
+++ b/pkg/cluster/docker.go
@@ -1,0 +1,13 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types"
+)
+
+type dockerClient interface {
+	ServerVersion(ctx context.Context) (types.Version, error)
+	Info(ctx context.Context) (types.Info, error)
+	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
+}

--- a/pkg/cluster/machine.go
+++ b/pkg/cluster/machine.go
@@ -10,8 +10,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/tilt-dev/ctlptl/pkg/api"
@@ -53,11 +51,6 @@ type d4mClient interface {
 	start(ctx context.Context) error
 }
 
-type dockerClient interface {
-	ServerVersion(ctx context.Context) (types.Version, error)
-	Info(ctx context.Context) (types.Info, error)
-}
-
 type dockerMachine struct {
 	dockerClient dockerClient
 	errOut       io.Writer
@@ -66,14 +59,7 @@ type dockerMachine struct {
 	os           string
 }
 
-func NewDockerMachine(ctx context.Context, errOut io.Writer) (*dockerMachine, error) {
-	client, err := client.NewClientWithOpts(client.FromEnv)
-	if err != nil {
-		return nil, err
-	}
-
-	client.NegotiateAPIVersion(ctx)
-
+func NewDockerMachine(ctx context.Context, client dockerClient, errOut io.Writer) (*dockerMachine, error) {
 	d4m, err := NewDockerDesktopClient()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/minikube-network:

fd978210d5b66c11b26938a6144aa95779cee710 (2020-11-16 20:39:30 -0500)
cluster: minikube 1.15 creates a unique network for each cluster

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics