### PR TITLE
cluster: add HostFromClusterNetwork to minikube

### DIFF
--- a/pkg/cluster/admin.go
+++ b/pkg/cluster/admin.go
@@ -12,6 +12,9 @@ import (
 type Admin interface {
 	EnsureInstalled(ctx context.Context) error
 	Create(ctx context.Context, desired *api.Cluster, registry *api.Registry) error
-	LocalRegistryHosting(registry *api.Registry) *localregistry.LocalRegistryHostingV1
+
+	// Infers the LocalRegistryHosting that this admin will try to configure.
+	LocalRegistryHosting(ctx context.Context, desired *api.Cluster, registry *api.Registry) (*localregistry.LocalRegistryHostingV1, error)
+
 	Delete(ctx context.Context, config *api.Cluster) error
 }

--- a/pkg/cluster/admin_docker_desktop.go
+++ b/pkg/cluster/admin_docker_desktop.go
@@ -32,8 +32,8 @@ func (a *dockerDesktopAdmin) Create(ctx context.Context, desired *api.Cluster, r
 	return fmt.Errorf("docker-desktop Kubernetes clusters are only available on macos and windows")
 }
 
-func (a *dockerDesktopAdmin) LocalRegistryHosting(registry *api.Registry) *localregistry.LocalRegistryHostingV1 {
-	return nil
+func (a *dockerDesktopAdmin) LocalRegistryHosting(ctx context.Context, desired *api.Cluster, registry *api.Registry) (*localregistry.LocalRegistryHostingV1, error) {
+	return nil, nil
 }
 
 func (a *dockerDesktopAdmin) Delete(ctx context.Context, config *api.Cluster) error {

--- a/pkg/cluster/admin_kind.go
+++ b/pkg/cluster/admin_kind.go
@@ -97,12 +97,12 @@ func (a *kindAdmin) inKindNetwork(registry *api.Registry) bool {
 	return false
 }
 
-func (a *kindAdmin) LocalRegistryHosting(registry *api.Registry) *localregistry.LocalRegistryHostingV1 {
+func (a *kindAdmin) LocalRegistryHosting(ctx context.Context, desired *api.Cluster, registry *api.Registry) (*localregistry.LocalRegistryHostingV1, error) {
 	return &localregistry.LocalRegistryHostingV1{
 		Host:                   fmt.Sprintf("localhost:%d", registry.Status.HostPort),
 		HostFromClusterNetwork: fmt.Sprintf("%s:%d", registry.Name, registry.Status.ContainerPort),
 		Help:                   "https://github.com/tilt-dev/ctlptl",
-	}
+	}, nil
 }
 
 func (a *kindAdmin) Delete(ctx context.Context, config *api.Cluster) error {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -539,7 +539,10 @@ func (c *Controller) Apply(ctx context.Context, desired *api.Cluster) (*api.Clus
 // Create a configmap on the cluster, so that other tools know that a registry
 // has been configured.
 func (c *Controller) createRegistryHosting(ctx context.Context, admin Admin, cluster *api.Cluster, reg *api.Registry) error {
-	hosting := admin.LocalRegistryHosting(reg)
+	hosting, err := admin.LocalRegistryHosting(ctx, cluster, reg)
+	if err != nil {
+		return err
+	}
 	if hosting == nil {
 		return nil
 	}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -408,11 +408,11 @@ func (a *fakeAdmin) Create(ctx context.Context, config *api.Cluster, registry *a
 	return nil
 }
 
-func (a *fakeAdmin) LocalRegistryHosting(registry *api.Registry) *localregistry.LocalRegistryHostingV1 {
+func (a *fakeAdmin) LocalRegistryHosting(ctx context.Context, cluster *api.Cluster, registry *api.Registry) (*localregistry.LocalRegistryHostingV1, error) {
 	return &localregistry.LocalRegistryHostingV1{
 		Host: fmt.Sprintf("localhost:%d", registry.Status.HostPort),
 		Help: "https://github.com/tilt-dev/ctlptl",
-	}
+	}, nil
 }
 
 func (a *fakeAdmin) Delete(ctx context.Context, config *api.Cluster) error {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/minikube-network2:

d00237a587f1490de0c0d0553f3fb120457b6227 (2020-11-16 21:10:42 -0500)
cluster: add HostFromClusterNetwork to minikube

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics