### PR TITLE
release: update goreleaser to use https

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,13 +35,13 @@ brews:
   commit_author:
     name: Tilt Dev
     email: hi@tilt.dev
-  url_template: "http://github.com/tilt-dev/ctlptl/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+  url_template: "https://github.com/tilt-dev/ctlptl/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   homepage: "https://ctlptl.dev/"
   description: "Making local Kubernetes clusters easy to set up and tear down"
   test: |
     system "#{bin}/ctlptl version"
 scoop:
-  url_template: "http://github.com/tilt-dev/tilt/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+  url_template: "https://github.com/tilt-dev/tilt/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   bucket:
     owner: tilt-dev
     name: scoop-bucket


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/goreleaser:

ae3b4a46598d17e577c843aece1d74c4e6cc5fcb (2020-11-18 09:54:12 -0500)
release: update goreleaser to use https

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics