### PR TITLE
cluster: applying a new cluster should make it the current. deleting a cluster should remove it from kubeconfig

### DIFF
--- a/pkg/cluster/admin_docker_desktop.go
+++ b/pkg/cluster/admin_docker_desktop.go
@@ -37,7 +37,7 @@ func (a *dockerDesktopAdmin) LocalRegistryHosting(ctx context.Context, desired *
 }
 
 func (a *dockerDesktopAdmin) Delete(ctx context.Context, config *api.Cluster) error {
-	if runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
+	if a.os != "darwin" && a.os != "windows" {
 		return fmt.Errorf("docker-desktop delete not implemented on: %s", runtime.GOOS)
 	}
 

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -1,0 +1,30 @@
+package cluster
+
+import (
+	"os/exec"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type configWriter interface {
+	SetContext(name string) error
+	DeleteContext(name string) error
+}
+
+type kubeconfigWriter struct {
+	iostreams genericclioptions.IOStreams
+}
+
+func (w kubeconfigWriter) SetContext(name string) error {
+	cmd := exec.Command("kubectl", "config", "set-context", name)
+	cmd.Stdout = w.iostreams.Out
+	cmd.Stderr = w.iostreams.ErrOut
+	return cmd.Run()
+}
+
+func (w kubeconfigWriter) DeleteContext(name string) error {
+	cmd := exec.Command("kubectl", "config", "delete-context", name)
+	cmd.Stdout = w.iostreams.Out
+	cmd.Stderr = w.iostreams.ErrOut
+	return cmd.Run()
+}


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/contexts:

71cd59843f25e2d363bb7ff52e1c8b9b13ca76a3 (2020-11-18 20:50:18 -0500)
cluster: applying a new cluster should make it the current. deleting a cluster should remove it from kubeconfig

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics