### PR TITLE
Fix ctlptl 404

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,7 +41,7 @@ brews:
   test: |
     system "#{bin}/ctlptl version"
 scoop:
-  url_template: "https://github.com/tilt-dev/tilt/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+  url_template: "https://github.com/tilt-dev/ctlptl/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   bucket:
     owner: tilt-dev
     name: scoop-bucket


### PR DESCRIPTION
Currently goreleaser is setup with the wrong url resulting in 404 within scoop, this should hopefully fix that, thanks.