### PR TITLE
test: add e2e tests for setting kubernetes version

### DIFF
--- a/test/kind-cluster-network/cluster.yaml
+++ b/test/kind-cluster-network/cluster.yaml
@@ -3,4 +3,4 @@ kind: Cluster
 name: kind-ctlptl-test-cluster
 product: kind
 registry: ctlptl-test-registry
-kubernetesVersion: v1.19.3
+kubernetesVersion: v1.18.8

--- a/test/kind-cluster-network/e2e.sh
+++ b/test/kind-cluster-network/e2e.sh
@@ -19,5 +19,15 @@ cat builder.yaml | sed "s/REGISTRY_HOST_PLACEHOLDER/$HOST/" | kubectl apply -f -
 kubectl wait --for=condition=complete job/ko-builder --timeout=180s
 cat simple-server.yaml | sed "s/REGISTRY_HOST_PLACEHOLDER/$HOST/" | kubectl apply -f -
 kubectl wait --for=condition=available deployment/simple-server --timeout=60s
+
+# Check to see we started the right kubernetes version.
+k8sVersion=$(ctlptl get cluster kind-ctlptl-test-cluster -o go-template --template='{{.status.kubernetesVersion}}')
+
 ctlptl delete -f cluster.yaml
+
+if [[ "$k8sVersion" != "v1.18.8" ]]; then
+    echo "Expected kubernetes version v1.18.8 but got $k8sVersion"
+    exit 1
+fi
+
 echo "kind-cluster-network test passed!"

--- a/test/minikube-cluster-network/cluster.yaml
+++ b/test/minikube-cluster-network/cluster.yaml
@@ -3,5 +3,4 @@ kind: Cluster
 name: minikube-ctlptl-test-cluster
 product: minikube
 registry: ctlptl-test-registry
-kubernetesVersion: v1.19.3
-
+kubernetesVersion: v1.18.8

--- a/test/minikube-cluster-network/e2e.sh
+++ b/test/minikube-cluster-network/e2e.sh
@@ -19,6 +19,15 @@ cat builder.yaml | sed "s/REGISTRY_HOST_PLACEHOLDER/$HOST/g" | kubectl apply -f 
 kubectl wait --for=condition=complete job/ko-builder --timeout=180s
 cat simple-server.yaml | sed "s/REGISTRY_HOST_PLACEHOLDER/$HOST/g" | kubectl apply -f -
 kubectl wait --for=condition=available deployment/simple-server --timeout=60s
+
+# Check to see we started the right kubernetes version.
+k8sVersion=$(ctlptl get cluster minikube-ctlptl-test-cluster -o go-template --template='{{.status.kubernetesVersion}}')
+
 ctlptl delete -f cluster.yaml
+
+if [[ "$k8sVersion" != "v1.18.8" ]]; then
+    echo "Expected kubernetes version v1.18.8 but got $k8sVersion"
+    exit 1
+fi
 
 echo "minikube-cluster-network test passed!"


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/versiontest:

adc57e15fb0f457844bf450324edab488985ae58 (2020-12-04 01:11:14 -0500)
test: add e2e tests for setting kubernetes version

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics