### PR TITLE
add an example of setting the kuberentes version to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ registry: ctlptl-registry
 EOF
 ```
 
-#### Minikube: with a built-in registry
+#### Minikube: with a built-in registry at Kubernetes v1.18.8
 
 Create:
 
 ```
-ctlptl create cluster minikube --registry=ctlptl-registry
+ctlptl create cluster minikube --registry=ctlptl-registry --kubernetes-version=v1.18.8
 ```
 
 or ensure exists:
@@ -109,6 +109,7 @@ apiVersion: ctlptl.dev/v1alpha1
 kind: Cluster
 product: minikube
 registry: ctlptl-registry
+kubernetesVersion: v1.18.8
 EOF
 ```
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/readme:

a31de53a61759ffcc3c8e7390fa3f557c09ee1bc (2020-12-04 01:28:17 -0500)
add an example of setting the kuberentes version to the docs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics