### PR TITLE
cluster: store the cluster spec in the cluster itself

### DIFF
--- a/examples/kind_custom_config.yaml
+++ b/examples/kind_custom_config.yaml
@@ -6,4 +6,7 @@ product: kind
 registry: ctlptl-registry
 kindV1Alpha4Cluster:
   name: my-cluster
+  nodes:
+  - role: control-plane
+  - role: worker
   


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/configmap:

7dd444fadbccf9fc1af7318dbdb14f1f41dc0160 (2020-12-08 12:26:09 -0500)
cluster: store the cluster spec in the cluster itself

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics