### PR TITLE
cluster: make ctlptl apply set the current context

### DIFF
--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -16,7 +16,7 @@ type kubeconfigWriter struct {
 }
 
 func (w kubeconfigWriter) SetContext(name string) error {
-	cmd := exec.Command("kubectl", "config", "set-context", name)
+	cmd := exec.Command("kubectl", "config", "use-context", name)
 	cmd.Stdout = w.iostreams.Out
 	cmd.Stderr = w.iostreams.ErrOut
 	return cmd.Run()


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/apply:

7c9d6db48a96d3025c6382c582f2e4f219bf000d (2020-12-08 13:07:11 -0500)
cluster: make ctlptl apply set the current context

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics