### PR TITLE
cluster: print the location of the registry on setup

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -666,7 +666,6 @@ func (c *Controller) createRegistryHosting(ctx context.Context, admin Admin, clu
 		return nil
 	}
 
-	_, _ = fmt.Fprintf(c.iostreams.ErrOut, "   Configuring %s for registry %s\n", cluster.Name, reg.Name)
 	client, err := c.client(cluster.Name)
 	if err != nil {
 		return err
@@ -684,7 +683,14 @@ func (c *Controller) createRegistryHosting(ctx context.Context, admin Admin, clu
 		},
 		Data: map[string]string{"localRegistryHosting.v1": string(data)},
 	}, metav1.CreateOptions{})
-	return err
+	if err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(c.iostreams.ErrOut, " 🔌 Connected cluster %s to registry %s at %s\n", cluster.Name, reg.Name, hosting.Host)
+	_, _ = fmt.Fprintf(c.iostreams.ErrOut, " 👐 Push images to the cluster like 'docker push %s/alpine'\n", hosting.Host)
+
+	return nil
 }
 
 func (c *Controller) Delete(ctx context.Context, name string) error {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/ports:

98d58ee5be54768cefe3097516f40a9e7bf56fb5 (2020-12-08 19:27:46 -0500)
cluster: print the location of the registry on setup

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics