### PR TITLE
circleci: don't use contexts on the normal build pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,21 +73,17 @@ workflows:
   version: 2
   build:
     jobs:
-      - build:
-          context: Tilt Slack Context
+      - build
       - e2e:
-          context: Tilt Slack Context
           requires:
             - build
       - release-dry-run:
-          context: Tilt Slack Context
           requires:
             - build
   release:
     jobs:
       - release:
           context:
-          - Tilt Slack Context
           - Tilt Release CLI Context
           filters:
             branches:


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/ci:

b36317f4912dfd6b7948e1d597a2c9c5cd5b6b83 (2020-12-17 09:56:39 -0500)
circleci: don't use contexts on the normal build pipeline
this prevents circleci from running contributor PRs

There's a better way to configure slack for this that doesn't
require contexts

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics