### PR TITLE
docs: add a contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Hacking on ctlptl
+
+So you want to make a change to `ctlptl`!
+
+## Contributing
+
+We welcome contributions, either as bug reports, feature requests, or pull requests.
+
+We want everyone to feel at home in this repo and its environs; please see our
+[**Code of Conduct**](https://docs.tilt.dev/code_of_conduct.html) for some rules
+that govern everyone's participation.
+
+## Commands
+
+Most of the commands for building and testing `ctlptl` should be familiar
+with anyone used to developing in Golang. But we have a Makefile to wrap
+common commands.
+
+### Run
+
+```
+go run ./cmd/ctlptl
+```
+
+### Install dev version
+
+```
+make install
+```
+
+### Unit tests
+
+```
+make test
+```
+
+### Integration tests
+
+```
+make e2e
+```
+
+### Release
+
+CircleCI will automatically build ctlptl releases when you push
+a new tag to master.
+
+```
+git pull origin main
+git fetch --tags
+git tag -a v0.x.y -m "v0.x.y"
+git push origin v0.x.y
+```

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ cluster](https://docs.tilt.dev/choosing_clusters.html) and example repos like
 
 `ctlptl` is a work in progress!
 
-We welcome contributions from the Kubernetes community to help make this better.
+We welcome [contributions](CONTRIBUTING.md) from the Kubernetes community to help make this better.
 
 We expect everyone -- users, contributors, followers, and employees alike -- to abide by our [**Code of Conduct**](CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/contributing:

56139d459144c103eb246e91d42e7d43e2b11402 (2021-01-11 12:35:57 -0500)
docs: add a contributing guide

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics