### PR TITLE
cluster: support for kind v0.11

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -36,7 +36,7 @@ RUN apt install -y apt-transport-https gnupg \
   && apt update && apt install -y kubectl
 
 # install Kind
-ENV KIND_VERSION=v0.10.0
+ENV KIND_VERSION=v0.11.0
 RUN set -exu \
   && curl -fLo ./kind-linux-amd64 "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64" \
   && chmod +x ./kind-linux-amd64 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
           sudo mv ./minikube-linux-amd64 /usr/local/bin/minikube
       - run: |
           set -ex
-          export KIND_VERSION=v0.10.0
+          export KIND_VERSION=v0.11.0
           curl -fLo ./kind-linux-amd64 "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
           chmod +x ./kind-linux-amd64
           sudo mv ./kind-linux-amd64 /usr/local/bin/kind

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -37,7 +37,7 @@ RUN apt install -y apt-transport-https gnupg \
   && apt update && apt install -y kubectl
 
 # install Kind
-ENV KIND_VERSION=v0.10.0
+ENV KIND_VERSION=v0.11.0
 RUN set -exu \
   && curl -fLo ./kind-linux-amd64 "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64" \
   && chmod +x ./kind-linux-amd64 \

--- a/pkg/cluster/admin_kind.go
+++ b/pkg/cluster/admin_kind.go
@@ -195,6 +195,16 @@ func (a *kindAdmin) getKindVersion(ctx context.Context) (string, error) {
 // This table must be built up manually from the Kind release notes each
 // time a new Kind version is released :\
 var kindK8sNodeTable = map[string]map[string]string{
+	"v0.11.0": map[string]string{
+		"1.21": "kindest/node:v1.21.1@sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad",
+		"1.20": "kindest/node:v1.20.7@sha256:e645428988191fc824529fd0bb5c94244c12401cf5f5ea3bd875eb0a787f0fe9",
+		"1.19": "kindest/node:v1.19.11@sha256:7664f21f9cb6ba2264437de0eb3fe99f201db7a3ac72329547ec4373ba5f5911",
+		"1.18": "kindest/node:v1.18.19@sha256:530378628c7c518503ade70b1df698b5de5585dcdba4f349328d986b8849b1ee",
+		"1.17": "kindest/node:v1.17.17@sha256:c581fbf67f720f70aaabc74b44c2332cc753df262b6c0bca5d26338492470c17",
+		"1.16": "kindest/node:v1.16.15@sha256:430c03034cd856c1f1415d3e37faf35a3ea9c5aaa2812117b79e6903d1fc9651",
+		"1.15": "kindest/node:v1.15.12@sha256:8d575f056493c7778935dd855ded0e95c48cb2fab90825792e8fc9af61536bf9",
+		"1.14": "kindest/node:v1.14.10@sha256:6033e04bcfca7c5f2a9c4ce77551e1abf385bcd2709932ec2f6a9c8c0aff6d4f",
+	},
 	"v0.10.0": map[string]string{
 		"1.20": "kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab",
 		"1.19": "kindest/node:v1.19.7@sha256:a70639454e97a4b733f9d9b67e12c01f6b0297449d5b9cbbef87473458e26dca",

--- a/test/kind-cluster-network/cluster.yaml
+++ b/test/kind-cluster-network/cluster.yaml
@@ -3,4 +3,4 @@ kind: Cluster
 name: kind-ctlptl-test-cluster
 product: kind
 registry: ctlptl-test-registry
-kubernetesVersion: v1.18.15
+kubernetesVersion: v1.18.19

--- a/test/kind-cluster-network/e2e.sh
+++ b/test/kind-cluster-network/e2e.sh
@@ -25,8 +25,8 @@ k8sVersion=$(ctlptl get cluster kind-ctlptl-test-cluster -o go-template --templa
 
 ctlptl delete -f cluster.yaml
 
-if [[ "$k8sVersion" != "v1.18.15" ]]; then
-    echo "Expected kubernetes version v1.18.15 but got $k8sVersion"
+if [[ "$k8sVersion" != "v1.18.19" ]]; then
+    echo "Expected kubernetes version v1.18.19 but got $k8sVersion"
     exit 1
 fi
 

--- a/test/minikube-cluster-network/cluster.yaml
+++ b/test/minikube-cluster-network/cluster.yaml
@@ -3,4 +3,4 @@ kind: Cluster
 name: minikube-ctlptl-test-cluster
 product: minikube
 registry: ctlptl-test-registry
-kubernetesVersion: v1.18.15
+kubernetesVersion: v1.18.19

--- a/test/minikube-cluster-network/e2e.sh
+++ b/test/minikube-cluster-network/e2e.sh
@@ -25,8 +25,8 @@ k8sVersion=$(ctlptl get cluster minikube-ctlptl-test-cluster -o go-template --te
 
 ctlptl delete -f cluster.yaml
 
-if [[ "$k8sVersion" != "v1.18.15" ]]; then
-    echo "Expected kubernetes version v1.18.15 but got $k8sVersion"
+if [[ "$k8sVersion" != "v1.18.19" ]]; then
+    echo "Expected kubernetes version v1.18.19 but got $k8sVersion"
     exit 1
 fi
 


### PR DESCRIPTION
Hello @landism,

Please review the following commits I made in branch nicks/kind11:

48c695ca624a3787b0d0bffb281076f3ddca301a (2021-05-19 19:20:22 -0400)
cluster: support for kind v0.11
updates all scripts to test against kind v0.11

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics