### PR TITLE
cmd: fix 'ctlptl create' segfault and improve i/o handling

### DIFF
--- a/pkg/cmd/apply.go
+++ b/pkg/cmd/apply.go
@@ -40,6 +40,8 @@ func (o *ApplyOptions) Command() *cobra.Command {
 		Run: o.Run,
 	}
 
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
 	o.FileNameFlags.AddFlags(cmd.Flags())
 	o.PrintFlags.AddFlags(cmd)
 

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -28,6 +27,8 @@ func (o *CreateOptions) Command() *cobra.Command {
 		Run: o.Run,
 	}
 
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
 	cmd.AddCommand(NewCreateClusterOptions().Command())
 	cmd.AddCommand(NewCreateRegistryOptions().Command())
 
@@ -35,6 +36,6 @@ func (o *CreateOptions) Command() *cobra.Command {
 }
 
 func (o *CreateOptions) Run(cmd *cobra.Command, args []string) {
-	_, _ = fmt.Fprintln(o.IOStreams.ErrOut, cmd.Help().Error())
+	_ = cmd.Help()
 	os.Exit(1)
 }

--- a/pkg/cmd/create_cluster.go
+++ b/pkg/cmd/create_cluster.go
@@ -41,6 +41,8 @@ func (o *CreateClusterOptions) Command() *cobra.Command {
 		Args: cobra.ExactArgs(1),
 	}
 
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
 	o.PrintFlags.AddFlags(cmd)
 	cmd.Flags().StringVar(&o.Cluster.Registry, "registry",
 		o.Cluster.Registry, "Connect the cluster to the named registry")

--- a/pkg/cmd/create_registry.go
+++ b/pkg/cmd/create_registry.go
@@ -41,6 +41,8 @@ func (o *CreateRegistryOptions) Command() *cobra.Command {
 		Args: cobra.ExactArgs(1),
 	}
 
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
 	o.PrintFlags.AddFlags(cmd)
 	cmd.Flags().IntVar(&o.Registry.Port, "port", o.Registry.Port, "The port to expose the registry on localhost. If not specified, chooses a random port")
 

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -46,6 +46,8 @@ func (o *DeleteOptions) Command() *cobra.Command {
 		Run: o.Run,
 	}
 
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
 	o.FileNameFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().BoolVar(&o.IgnoreNotFound, "ignore-not-found", o.IgnoreNotFound, "If the requested object does not exist the command will return exit code 0.")

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -44,6 +44,8 @@ func (o *GetOptions) Command() *cobra.Command {
 		Args: cobra.MaximumNArgs(2),
 	}
 
+	cmd.SetOut(o.Out)
+	cmd.SetErr(o.ErrOut)
 	o.PrintFlags.AddFlags(cmd)
 
 	cmd.Flags().BoolVar(&o.IgnoreNotFound, "ignore-not-found", o.IgnoreNotFound, "If the requested object does not exist the command will return exit code 0.")


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/issue114:

5284a7689ab2396d026dedcb84530f42f9291276 (2021-06-11 19:43:27 -0400)
cmd: fix 'ctlptl create' segfault and improve i/o handling
Fixes https://github.com/tilt-dev/ctlptl/issues/114

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics