### PR TITLE
Simplify command-line install script

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,14 +34,14 @@ On macOS:
 
 ```bash
 CTLPTL_VERSION="0.5.0"
-curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.mac.x86_64.tar.gz | tar -xzv -C /usr/local/bin ctlptl
+curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.mac.x86_64.tar.gz | sudo tar -xzv -C /usr/local/bin ctlptl
 ```
 
 On Linux:
 
 ```bash
 CTLPTL_VERSION="0.5.0"
-curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.x86_64.tar.gz | tar -xzv -C /usr/local/bin ctlptl
+curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.x86_64.tar.gz | sudo tar -xzv -C /usr/local/bin ctlptl
 ```
 
 On Windows:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,17 +33,15 @@ download the pre-build binaries for your architecture.
 On macOS:
 
 ```bash
-export CTLPTL_VERSION="0.5.0"
-curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.mac.x86_64.tar.gz | tar -xzv ctlptl && \
-  sudo mv ctlptl /usr/local/bin/ctlptl
+CTLPTL_VERSION="0.5.0"
+curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.mac.x86_64.tar.gz | tar -xzv -C /usr/local/bin ctlptl
 ```
 
 On Linux:
 
 ```bash
-export CTLPTL_VERSION="0.5.0"
-curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.x86_64.tar.gz | tar -xzv ctlptl && \
-  sudo mv ctlptl /usr/local/bin/ctlptl
+CTLPTL_VERSION="0.5.0"
+curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.x86_64.tar.gz | tar -xzv -C /usr/local/bin ctlptl
 ```
 
 On Windows:


### PR DESCRIPTION
- `export` is not needed
- `tar` can install `ctlptl` directly to `/usr/local/bin`