### PR TITLE
cluster: adjust timeouts to wait 5 minutes for kubernetes to start

### DIFF
--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -403,16 +403,17 @@ func newFixture(t *testing.T) *fixture {
 
 	registryCtl := &fakeRegistryController{}
 	controller := &Controller{
-		iostreams:              iostreams,
-		admins:                 make(map[Product]Admin),
-		config:                 *config,
-		configWriter:           configWriter,
-		dmachine:               dmachine,
-		configLoader:           configLoader,
-		clientLoader:           clientLoader,
-		clients:                make(map[string]kubernetes.Interface),
-		registryCtl:            registryCtl,
-		waitAfterCreateTimeout: time.Millisecond,
+		iostreams:                   iostreams,
+		admins:                      make(map[Product]Admin),
+		config:                      *config,
+		configWriter:                configWriter,
+		dmachine:                    dmachine,
+		configLoader:                configLoader,
+		clientLoader:                clientLoader,
+		clients:                     make(map[string]kubernetes.Interface),
+		registryCtl:                 registryCtl,
+		waitForKubeConfigTimeout:    time.Millisecond,
+		waitForClusterCreateTimeout: time.Millisecond,
 	}
 	return &fixture{
 		t:            t,


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/update2:

6665ca0f74c16196abdb1dbc96b917c9f6733ee5 (2021-09-28 15:38:06 -0400)
cluster: adjust timeouts to wait 5 minutes for kubernetes to start
fixes https://github.com/tilt-dev/ctlptl/issues/139

bf4e11cb0371e854ef20e4409ac7eba74f67fa37 (2021-09-23 17:04:46 -0400)
update install

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics