### PR TITLE
Increase default max pods limit in minikube

### DIFF
--- a/pkg/cluster/admin_minikube.go
+++ b/pkg/cluster/admin_minikube.go
@@ -46,7 +46,7 @@ func (a *minikubeAdmin) Create(ctx context.Context, desired *api.Cluster, regist
 	clusterName := desired.Name
 
 	// TODO(nick): Let the user pass in their own Minikube configuration.
-	args := []string{"start", "--driver=docker", "--container-runtime=containerd", "-p", clusterName}
+	args := []string{"start", "--driver=docker", "--container-runtime=containerd", "--extra-config=kubelet.max-pods=500", "-p", clusterName}
 	if desired.MinCPUs != 0 {
 		args = append(args, fmt.Sprintf("--cpus=%d", desired.MinCPUs))
 	}


### PR DESCRIPTION
Given that ctlptl is only designed for test and development clusters, and uses only one node by default, I believe it is appropriate to increase the max-pods from the default of 110 to 500 (can increase this further if desired). This allows for microservices architectures with a significant number of pods to be tested without running into kubernetes limits. This can be removed once the existing cli/crd allow for passing all minikube customization options (I believe this is tracked in #86). Thanks.