### PR TITLE
Single line to work in bash and fish-3.1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,8 +40,7 @@ curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION
 On Linux:
 
 ```bash
-CTLPTL_VERSION="0.6.1"
-curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.x86_64.tar.gz | sudo tar -xzv -C /usr/local/bin ctlptl
+CTLPTL_VERSION="0.6.1" curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.x86_64.tar.gz | sudo tar -xzv -C /usr/local/bin ctlptl
 ```
 
 On Windows:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,7 +40,8 @@ curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION
 On Linux:
 
 ```bash
-CTLPTL_VERSION="0.6.1" curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.x86_64.tar.gz | sudo tar -xzv -C /usr/local/bin ctlptl
+CTLPTL_VERSION="0.6.1" \
+curl -fsSL https://github.com/tilt-dev/ctlptl/releases/download/v$CTLPTL_VERSION/ctlptl.$CTLPTL_VERSION.linux.x86_64.tar.gz | sudo tar -xzv -C /usr/local/bin ctlptl
 ```
 
 On Windows:


### PR DESCRIPTION
Moving to a single line allows the command to work on `bash` and in `fish v3.1` by merely copying and pasting.