### PR TITLE
Support Kubernetes 1.22 and 1.23 for kind

### DIFF
--- a/pkg/cluster/admin_kind.go
+++ b/pkg/cluster/admin_kind.go
@@ -198,6 +198,8 @@ func (a *kindAdmin) getKindVersion(ctx context.Context) (string, error) {
 // time a new Kind version is released :\
 var kindK8sNodeTable = map[string]map[string]string{
 	"v0.11.1": map[string]string{
+		"1.23": "kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac",
+		"1.22": "kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047",
 		"1.21": "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6",
 		"1.20": "kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9",
 		"1.19": "kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729",

--- a/pkg/cluster/admin_kind_test.go
+++ b/pkg/cluster/admin_kind_test.go
@@ -30,6 +30,10 @@ func TestNodeImage(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "kindest/node:v1.20.2@sha256:8f7ea6e7642c0da54f04a7ee10431549c0257315b3a634f6ef2fecaaedb19bab", img)
 
+	img, err = a.getNodeImage(ctx, "v0.11.1", "v1.23")
+	assert.NoError(t, err)
+	assert.Equal(t, "kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac", img)
+
 	img, err = a.getNodeImage(ctx, "v0.8.1", "v1.16.1")
 	assert.NoError(t, err)
 	assert.Equal(t, "kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765", img)


### PR DESCRIPTION
The release note says k8s 1.22 and 1.23 images are known to work well
https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1

Signed-off-by: zoetrope <a.ikezoe@gmail.com>