### PR TITLE
cluster: change the docker-desktop socket path

### DIFF
--- a/pkg/cluster/docker_desktop_dial.go
+++ b/pkg/cluster/docker_desktop_dial.go
@@ -11,13 +11,19 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
-func dockerDesktopSocketPath() (string, error) {
+func dockerDesktopSocketPaths() ([]string, error) {
 	homedir, err := homedir.Dir()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return filepath.Join(homedir, "Library/Containers/com.docker.docker/Data/gui-api.sock"), nil
+	return []string{
+		// Older versions of docker desktop use this socket.
+		filepath.Join(homedir, "Library/Containers/com.docker.docker/Data/gui-api.sock"),
+
+		// Newer versions of docker desktop use this socket.
+		filepath.Join(homedir, "Library/Containers/com.docker.docker/Data/backend.sock"),
+	}, nil
 }
 
 func dialDockerDesktop(socketPath string) (net.Conn, error) {

--- a/pkg/cluster/docker_desktop_dial_windows.go
+++ b/pkg/cluster/docker_desktop_dial_windows.go
@@ -8,8 +8,8 @@ import (
 	"gopkg.in/natefinch/npipe.v2"
 )
 
-func dockerDesktopSocketPath() (string, error) {
-	return `\\.\pipe\dockerWebApiServer`, nil
+func dockerDesktopSocketPaths() ([]string, error) {
+	return []string{`\\.\pipe\dockerWebApiServer`}, nil
 }
 
 func dialDockerDesktop(socketPath string) (net.Conn, error) {


### PR DESCRIPTION
Hello @nicksieger, @milas,

Please review the following commits I made in branch nicks/socket:

35d10644e5ef0d5a895e6dc533d9abac652251a6 (2022-01-13 16:56:48 -0500)
cluster: change the docker-desktop socket path
Fixes https://github.com/tilt-dev/ctlptl/issues/176

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics