### PR TITLE
Fixes containerd cri mirror updates

### DIFF
--- a/pkg/cluster/admin_minikube.go
+++ b/pkg/cluster/admin_minikube.go
@@ -181,10 +181,10 @@ func (a *minikubeAdmin) applyContainerdPatch(ctx context.Context, desired *api.C
 		cmd := exec.CommandContext(ctx, "minikube", "-p", desired.Name, "--node", node,
 			"ssh", "sudo", "sed", `\-i`,
 			fmt.Sprintf(
-				`s,\\\[plugins.cri.registry.mirrors\\\],[plugins.cri.registry.mirrors]\\\n`+
-					`\ \ \ \ \ \ \ \ [plugins.cri.registry.mirrors.\\\"localhost:%d\\\"]\\\n`+
+				`s,\\\[plugins.\\\(\\\"\\\?.*cri\\\"\\\?\\\).registry.mirrors\\\],[plugins.\\\1.registry.mirrors]\\\n`+
+					`\ \ \ \ \ \ \ \ [plugins.\\\1.registry.mirrors.\\\"localhost:%d\\\"]\\\n`+
 					`\ \ \ \ \ \ \ \ \ \ endpoint\ =\ [\\\"http://%s:%d\\\"]\\\n`+
-					`\ \ \ \ \ \ \ \ [plugins.cri.registry.mirrors.\\\"%s:%d\\\"]\\\n`+
+					`\ \ \ \ \ \ \ \ [plugins.\\\1.registry.mirrors.\\\"%s:%d\\\"]\\\n`+
 					`\ \ \ \ \ \ \ \ \ \ endpoint\ =\ [\\\"http://%s:%d\\\"],`,
 				registry.Status.HostPort, networkHost, registry.Status.ContainerPort,
 				networkHost, registry.Status.ContainerPort,


### PR DESCRIPTION
- Updates the sed command that modifies the containerd config.toml file
  to be able to edit the mirror configurations as they are different
  between minikube v1.24.0 and v1.25.0. The v1.24.0 follows the form
  '[plugins.cri.registry.mirrors]' and v1.25.0 follows the form
  '[plugins."io.containerd.grpc.v1.cri".registry.mirrors]'.

I manually tested this change between both versions of the configuration file but the way that this is currently done doesn't make it easy for testing with the multiple escapes between the local shell and the `minikube ssh` pass.