### PR TITLE
Fixes registry re-attachment with minikube

### DIFF
--- a/pkg/cluster/admin_minikube.go
+++ b/pkg/cluster/admin_minikube.go
@@ -139,6 +139,16 @@ func (a *minikubeAdmin) ensureRegistryDisconnected(ctx context.Context, registry
 		if err != nil {
 			return errors.Wrap(err, "disconnecting registry")
 		}
+
+		// Remove the network from the current set of networks attached to the registry. This allows the registry to be reconnected after
+		// a cluster delete and create operation without removing the registry
+		networks := []string{}
+		for _, n := range registry.Status.Networks {
+			if n != networkMode.UserDefined() {
+				networks = append(networks, n)
+			}
+		}
+		registry.Status.Networks = networks
 	}
 	return nil
 }


### PR DESCRIPTION
After deleting a minikube cluster with `ctlptl delete cluster minikube` the `ctlptl-registry` container is left running. When a new minikube cluster is created, the existing ctlptl-registry container is not reattached to the minikube Docker network so it cannot be reached inside of the cluster to pull containers. 

This PR deletes the minikube or UserDefined network from the list of networks that the `ctlptl-registry` container is attached to when disconnecting during minikube cluster creation.