### PR TITLE
Allow DOCKER_HOST to use the SSH scheme

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denisbrodbeck/machineid v1.0.0 // indirect
+	github.com/docker/cli v20.10.13+incompatible // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/denisbrodbeck/machineid v1.0.0 h1:6tMg1EaB3r/EfIqKS0on/pvkRBZJAXH3fmS
 github.com/denisbrodbeck/machineid v1.0.0/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/cli v20.10.13+incompatible h1:o/STAn7e+b/pQ6keReGRoewVmAgXUkZAMQ8st4vHdKg=
+github.com/docker/cli v20.10.13+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200730172259-9f28837c1d93+incompatible h1:UcwmC9cQLDd+vVRaZ9K06KzmMBWGTqa/lpdkoIAyjt8=

--- a/internal/socat/socat.go
+++ b/internal/socat/socat.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/shirou/gopsutil/v3/process"
+	"github.com/tilt-dev/ctlptl/pkg/docker"
 )
 
 const serviceName = "ctlptl-portforward-service"
@@ -30,7 +31,11 @@ func NewController(client ContainerClient) *Controller {
 }
 
 func DefaultController(ctx context.Context) (*Controller, error) {
-	client, err := client.NewClientWithOpts(client.FromEnv)
+	opts, err := docker.ClientOpts()
+	if err != nil {
+		return nil, err
+	}
+	client, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/docker.go
+++ b/pkg/cluster/docker.go
@@ -24,7 +24,11 @@ type dockerWrapper struct {
 func (w *dockerWrapper) IsLocalHost() bool { return w.isLocalHost }
 
 func newDockerWrapperFromEnv(ctx context.Context) (*dockerWrapper, error) {
-	c, err := client.NewClientWithOpts(client.FromEnv)
+	opts, err := docker.ClientOpts()
+	if err != nil {
+		return nil, err
+	}
+	c, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -33,15 +33,15 @@ func IsLocalHost(dockerHost string) bool {
 // environment variable is an SSH url, otherwise it will return client.FromEnv for a standard
 // connection. This function returns an error if DOCKER_HOST is an invalid URL.
 func ClientOpts() ([]client.Opt, error) {
+	opts := []client.Opt{client.FromEnv}
 	connHelperOpts, err := connectionHelperOpts()
 	if err != nil {
 		return nil, err
 	}
 	if connHelperOpts != nil {
-		return connHelperOpts, nil
-	} else {
-		return []client.Opt{client.FromEnv}, nil
+		opts = append(opts, connHelperOpts...)
 	}
+	return opts, nil
 }
 
 // connectionHelperOpts uses the Docker CLI's connection helpers to check if the DOCKER_HOST

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -24,9 +24,11 @@ import (
 	"github.com/tilt-dev/ctlptl/pkg/docker"
 )
 
-var typeMeta = api.TypeMeta{APIVersion: "ctlptl.dev/v1alpha1", Kind: "Registry"}
-var listTypeMeta = api.TypeMeta{APIVersion: "ctlptl.dev/v1alpha1", Kind: "RegistryList"}
-var groupResource = schema.GroupResource{Group: "ctlptl.dev", Resource: "registries"}
+var (
+	typeMeta      = api.TypeMeta{APIVersion: "ctlptl.dev/v1alpha1", Kind: "Registry"}
+	listTypeMeta  = api.TypeMeta{APIVersion: "ctlptl.dev/v1alpha1", Kind: "RegistryList"}
+	groupResource = schema.GroupResource{Group: "ctlptl.dev", Resource: "registries"}
+)
 
 const registryImageRef = "docker.io/library/registry:2" // The registry everyone uses.
 
@@ -76,7 +78,11 @@ func NewController(iostreams genericclioptions.IOStreams, dockerClient Container
 }
 
 func DefaultController(ctx context.Context, iostreams genericclioptions.IOStreams) (*Controller, error) {
-	dockerClient, err := client.NewClientWithOpts(client.FromEnv)
+	opts, err := docker.ClientOpts()
+	if err != nil {
+		return nil, err
+	}
+	dockerClient, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit pulls in the Docker CLI's connhelper package which provides some
wrapper code for creating a client that can communicate with a Docker instance
over SSH.

The connection helper package is being used by adding a new ClientOpts()
function that will return a slice of client.Opt values appropriate for
connecting to DOCKER_HOST. If DOCKER_HOST is an ssh url, a set of opts built
using connhelper will be returned. If not, a set containing only client.FromEnv
will be returned, preserving the existing behavior of ctlptl.