### PR TITLE
docker: use the API instead of a subshell for connecting networks

### DIFF
--- a/pkg/cluster/admin_kind_test.go
+++ b/pkg/cluster/admin_kind_test.go
@@ -15,7 +15,7 @@ func TestNodeImage(t *testing.T) {
 		Out:    os.Stdout,
 		ErrOut: os.Stderr,
 	}
-	a := newKindAdmin(iostreams)
+	a := newKindAdmin(iostreams, &fakeDockerClient{})
 	ctx := context.Background()
 
 	img, err := a.getNodeImage(ctx, "v0.9.0", "v1.19")

--- a/pkg/cluster/admin_minikube.go
+++ b/pkg/cluster/admin_minikube.go
@@ -118,8 +118,7 @@ func (a *minikubeAdmin) Create(ctx context.Context, desired *api.Cluster, regist
 // Minikube v0.15.0+ creates a unique network for each minikube cluster.
 func (a *minikubeAdmin) ensureRegistryConnected(ctx context.Context, registry *api.Registry, networkMode container.NetworkMode) error {
 	if networkMode.IsUserDefined() && !a.inRegistryNetwork(registry, networkMode) {
-		cmd := exec.CommandContext(ctx, "docker", "network", "connect", networkMode.UserDefined(), registry.Name)
-		err := cmd.Run()
+		err := a.dockerClient.NetworkConnect(ctx, networkMode.UserDefined(), registry.Name, nil)
 		if err != nil {
 			return errors.Wrap(err, "connecting registry")
 		}
@@ -134,8 +133,7 @@ func (a *minikubeAdmin) ensureRegistryConnected(ctx context.Context, registry *a
 // https://github.com/tilt-dev/ctlptl/issues/144
 func (a *minikubeAdmin) ensureRegistryDisconnected(ctx context.Context, registry *api.Registry, networkMode container.NetworkMode) error {
 	if networkMode.IsUserDefined() && a.inRegistryNetwork(registry, networkMode) {
-		cmd := exec.CommandContext(ctx, "docker", "network", "disconnect", networkMode.UserDefined(), registry.Name)
-		err := cmd.Run()
+		err := a.dockerClient.NetworkDisconnect(ctx, networkMode.UserDefined(), registry.Name, false)
 		if err != nil {
 			return errors.Wrap(err, "disconnecting registry")
 		}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -246,7 +246,7 @@ func (c *Controller) admin(ctx context.Context, product clusterid.Product) (Admi
 
 		admin = newDockerDesktopAdmin()
 	case clusterid.ProductKIND:
-		admin = newKindAdmin(c.iostreams)
+		admin = newKindAdmin(c.iostreams, dockerClient)
 	case clusterid.ProductK3D:
 		admin = newK3dAdmin(c.iostreams)
 	case clusterid.ProductMinikube:

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tilt-dev/clusterid"
@@ -489,6 +490,14 @@ func (c *fakeDockerClient) ContainerInspect(ctx context.Context, id string) (typ
 }
 
 func (d *fakeDockerClient) ContainerRemove(ctx context.Context, id string, options types.ContainerRemoveOptions) error {
+	return nil
+}
+
+func (d *fakeDockerClient) NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error {
+	return nil
+}
+
+func (d *fakeDockerClient) NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error {
 	return nil
 }
 

--- a/pkg/cluster/docker.go
+++ b/pkg/cluster/docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/tilt-dev/ctlptl/pkg/docker"
 )
@@ -14,6 +15,8 @@ type dockerClient interface {
 	Info(ctx context.Context) (types.Info, error)
 	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
 	ContainerRemove(ctx context.Context, id string, options types.ContainerRemoveOptions) error
+	NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
+	NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error
 }
 
 type dockerWrapper struct {


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/docker:

a4c971a9ca27d071b108f637ece5f6792bf2b6d9 (2022-03-30 18:54:50 -0400)
docker: use the API instead of a subshell for connecting networks

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics