### PR TITLE
Treat non default sockets as remote

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -25,7 +25,9 @@ func IsLocalHost(dockerHost string) bool {
 		strings.HasPrefix(dockerHost, "npipe:") ||
 
 		// https://github.com/moby/moby/blob/master/client/client_unix.go#L6
-		strings.HasPrefix(dockerHost, "unix:")
+		(strings.HasPrefix(dockerHost, "unix:") &&
+			// https://docs.docker.com/desktop/faqs/#how-do-i-connect-to-the-remote-docker-engine-api
+			strings.Contains(dockerHost, "/var/run/docker.sock"))
 }
 
 // ClientOpts returns an appropiate slice of client.Opt values for connecting to a Docker client.


### PR DESCRIPTION
Fixes #196

## Questions

1. Wasn't sure if it would be better to check if the socket contains OR is equal to the default `unix:///var/run/docker.sock` based on https://docs.docker.com/desktop/faqs/#how-do-i-connect-to-the-remote-docker-engine-api
 
It felt a bit iffy to me to include `&& !strings.Contains(dockerHost, "./colima")` since _another colima like tool_ would then not be supported.

### Problems

On the first create:

```bash
$ go run ./cmd/ctlptl create cluster kind --name kind-2
Creating cluster "2" ...
 ✓ Ensuring node image (kindest/node:v1.23.4) 🖼
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
Set kubectl context to "kind-2"
You can now use your cluster with:

kubectl cluster-info --context kind-2

Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/
Switched to context "kind-2".
 🎮 Env DOCKER_HOST set. Assuming remote Docker and forwarding apiserver to localhost:56634
socat not installed: ctlptl requires 'socat' to be installed when setting up clusters on a remote Docker daemon
exit status 1
```

But I think this is now a _after cltptl issued the kind cmd_ and not a ctlptl problem.  This did create a cluser `kind-2` anyway, it just didn't print out the last "cluster created" part.

With socat:

```
$ go run ./cmd/ctlptl create cluster kind --name kind-2
Creating cluster "2" ...
 ✓ Ensuring node image (kindest/node:v1.23.4) 🖼
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
Set kubectl context to "kind-2"
You can now use your cluster with:

kubectl cluster-info --context kind-2

Have a nice day! 👋
Switched to context "kind-2".
 🎮 Env DOCKER_HOST set. Assuming remote Docker and forwarding apiserver to localhost:57026
cluster.ctlptl.dev/kind-2 created

$ go run ./cmd/ctlptl delete cluster kind-2
Deleting cluster "2" ...
cluster.ctlptl.dev/kind-2 deleted
```

However, if we want to just check for `/.colima/docker.sock`, I'm okay with that too.

