### PR TITLE
docker: split IsLocalHost() into two functions

### DIFF
--- a/pkg/cluster/admin_docker_desktop.go
+++ b/pkg/cluster/admin_docker_desktop.go
@@ -28,8 +28,8 @@ func (a *dockerDesktopAdmin) Create(ctx context.Context, desired *api.Cluster, r
 		return fmt.Errorf("ctlptl currently does not support connecting a registry to docker-desktop")
 	}
 
-	isLocalHost := docker.IsLocalHost(a.host)
-	if !isLocalHost {
+	isLocalDockerEngine := docker.IsLocalDockerEngineHost(a.host)
+	if !isLocalDockerEngine {
 		return fmt.Errorf("docker-desktop clusters are only available on a local Docker engine. Current DOCKER_HOST: %s",
 			a.host)
 	}
@@ -45,8 +45,8 @@ func (a *dockerDesktopAdmin) LocalRegistryHosting(ctx context.Context, desired *
 }
 
 func (a *dockerDesktopAdmin) Delete(ctx context.Context, config *api.Cluster) error {
-	isLocalHost := docker.IsLocalHost(a.host)
-	if !isLocalHost {
+	isLocalDockerEngine := docker.IsLocalDockerEngineHost(a.host)
+	if !isLocalDockerEngine {
 		return fmt.Errorf("docker-desktop cannot be deleted from a remote DOCKER_HOST: %s", a.host)
 	}
 	if a.os != "darwin" && a.os != "windows" {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -239,7 +239,7 @@ func (c *Controller) admin(ctx context.Context, product clusterid.Product) (Admi
 
 	switch product {
 	case clusterid.ProductDockerDesktop:
-		if !dockerClient.IsLocalHost() {
+		if !dockerClient.IsLocalDockerEngine() {
 			return nil, fmt.Errorf("Detected remote DOCKER_HOST. Remote Docker engines do not support Docker Desktop clusters: %s",
 				docker.GetHostEnv())
 		}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -465,7 +465,7 @@ type fakeDockerClient struct {
 	ncpu         int
 }
 
-func (c *fakeDockerClient) IsLocalHost() bool {
+func (c *fakeDockerClient) IsLocalDockerEngine() bool {
 	return !c.isRemoteHost
 }
 

--- a/pkg/cluster/docker.go
+++ b/pkg/cluster/docker.go
@@ -10,7 +10,7 @@ import (
 )
 
 type dockerClient interface {
-	IsLocalHost() bool
+	IsLocalDockerEngine() bool
 	ServerVersion(ctx context.Context) (types.Version, error)
 	Info(ctx context.Context) (types.Info, error)
 	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
@@ -21,10 +21,10 @@ type dockerClient interface {
 
 type dockerWrapper struct {
 	*client.Client
-	isLocalHost bool
+	isLocalDE bool
 }
 
-func (w *dockerWrapper) IsLocalHost() bool { return w.isLocalHost }
+func (w *dockerWrapper) IsLocalDockerEngine() bool { return w.isLocalDE }
 
 func newDockerWrapperFromEnv(ctx context.Context) (*dockerWrapper, error) {
 	opts, err := docker.ClientOpts()
@@ -37,9 +37,9 @@ func newDockerWrapperFromEnv(ctx context.Context) (*dockerWrapper, error) {
 	}
 
 	c.NegotiateAPIVersion(ctx)
-	isLocalHost := docker.IsLocalHost(docker.GetHostEnv())
+	isLocalDE := docker.IsLocalDockerEngineHost(docker.GetHostEnv())
 	return &dockerWrapper{
-		Client:      c,
-		isLocalHost: isLocalHost,
+		Client:    c,
+		isLocalDE: isLocalDE,
 	}, nil
 }

--- a/pkg/cluster/machine.go
+++ b/pkg/cluster/machine.go
@@ -90,7 +90,7 @@ func (m dockerMachine) EnsureExists(ctx context.Context) error {
 		return nil
 	}
 
-	if !m.dockerClient.IsLocalHost() {
+	if !m.dockerClient.IsLocalDockerEngine() {
 		return fmt.Errorf("Detected remote DOCKER_HOST, but no Docker running. Host: %q. Error: %v",
 			docker.GetHostEnv(), err)
 	}
@@ -122,7 +122,7 @@ func (m dockerMachine) EnsureExists(ctx context.Context) error {
 func (m dockerMachine) Restart(ctx context.Context, desired, existing *api.Cluster) error {
 	canChangeCPUs := false
 	isLocalDockerDesktop := false
-	if m.dockerClient.IsLocalHost() && (m.os == "darwin" || m.os == "windows") {
+	if m.dockerClient.IsLocalDockerEngine() && (m.os == "darwin" || m.os == "windows") {
 		canChangeCPUs = true // DockerForMac and DockerForWindows can change the CPU on the VM
 		isLocalDockerDesktop = true
 	} else if clusterid.Product(desired.Product) == clusterid.ProductMinikube {

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -8,24 +8,27 @@ import (
 )
 
 type dockerHostTestCase struct {
-	host     string
-	expected bool
+	host          string
+	localDaemon   bool
+	dockerDesktop bool
 }
 
 func TestIsLocalDockerHost(t *testing.T) {
 	cases := []dockerHostTestCase{
-		dockerHostTestCase{"", true},
-		dockerHostTestCase{"tcp://localhost:2375", true},
-		dockerHostTestCase{"tcp://127.0.0.1:2375", true},
-		dockerHostTestCase{"npipe:////./pipe/docker_engine", true},
-		dockerHostTestCase{"unix:///var/run/docker.sock", true},
-		dockerHostTestCase{"tcp://cluster:2375", false},
-		dockerHostTestCase{"http://cluster:2375", false},
+		dockerHostTestCase{"", true, true},
+		dockerHostTestCase{"tcp://localhost:2375", true, true},
+		dockerHostTestCase{"tcp://127.0.0.1:2375", true, true},
+		dockerHostTestCase{"npipe:////./pipe/docker_engine", true, true},
+		dockerHostTestCase{"unix:///var/run/docker.sock", true, true},
+		dockerHostTestCase{"tcp://cluster:2375", false, false},
+		dockerHostTestCase{"http://cluster:2375", false, false},
+		dockerHostTestCase{"unix:///Users/USER/.colima/docker.sock", true, false},
 	}
 	for i, c := range cases {
 		c := c
 		t.Run(fmt.Sprintf("%s-%d", t.Name(), i), func(t *testing.T) {
-			assert.Equal(t, c.expected, IsLocalHost(c.host))
+			assert.Equal(t, c.localDaemon, IsLocalHost(c.host))
+			assert.Equal(t, c.dockerDesktop, IsLocalDockerEngineHost(c.host))
 		})
 	}
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/colima:

28292aa2f77150996fb4e7d488cbce352248f3b5 (2022-03-31 12:59:04 -0400)
docker: split IsLocalHost() into two functions
When callers use this function, they care about two things:
- Whether the docker server is running remotely, so needs port-forwarding.
- Whether the docker server is the Real Docker Engine, which has additional APIs for VMs

This change splits those two use-cases, so that we work properly with colima
and other docker-compatible runtimes.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics