### PR TITLE
docker: use a docker API client instead of a subshell

### DIFF
--- a/internal/dctr/run.go
+++ b/internal/dctr/run.go
@@ -1,0 +1,96 @@
+package dctr
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// Docker Container client.
+type Client interface {
+	ImagePull(ctx context.Context, image string, options types.ImagePullOptions) (io.ReadCloser, error)
+
+	ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error)
+	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
+	ContainerRemove(ctx context.Context, id string, options types.ContainerRemoveOptions) error
+	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *specs.Platform, containerName string) (container.ContainerCreateCreatedBody, error)
+	ContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) error
+}
+
+// A simplified remove-container-if-necessary helper.
+func RemoveIfNecessary(ctx context.Context, c Client, name string) error {
+	container, err := c.ContainerInspect(ctx, name)
+	if err != nil {
+		if client.IsErrNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if container.ContainerJSONBase == nil {
+		return nil
+	}
+
+	return c.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{
+		Force: true,
+	})
+}
+
+// A simplified run-container-and-detach helper for background support containers (like socat and the registry).
+func Run(ctx context.Context, c Client, name string, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig) error {
+
+	ctr, err := c.ContainerInspect(ctx, name)
+	if err == nil && (ctr.ContainerJSONBase != nil && ctr.State.Running) {
+		// The service is already running!
+		return nil
+	} else if err == nil {
+		// The service exists, but is not running
+		err := c.ContainerRemove(ctx, name, types.ContainerRemoveOptions{Force: true})
+		if err != nil {
+			return fmt.Errorf("creating %s: %v", name, err)
+		}
+	} else if !client.IsErrNotFound(err) {
+		return fmt.Errorf("inspecting %s: %v", name, err)
+	}
+
+	resp, err := c.ContainerCreate(ctx, config, hostConfig, networkingConfig, nil, name)
+	if err != nil {
+		if !client.IsErrNotFound(err) {
+			return fmt.Errorf("creating %s: %v", name, err)
+		}
+
+		err := pull(ctx, c, config.Image)
+		if err != nil {
+			return fmt.Errorf("pulling image %s: %v", config.Image, err)
+		}
+
+		resp, err = c.ContainerCreate(ctx, config, hostConfig, networkingConfig, nil, name)
+		if err != nil {
+			return fmt.Errorf("creating %s: %v", name, err)
+		}
+	}
+
+	id := resp.ID
+	err = c.ContainerStart(ctx, id, types.ContainerStartOptions{})
+	if err != nil {
+		return fmt.Errorf("starting %s: %v", name, err)
+	}
+	return nil
+}
+
+func pull(ctx context.Context, c Client, image string) error {
+	resp, err := c.ImagePull(ctx, image, types.ImagePullOptions{})
+	if err != nil {
+		return fmt.Errorf("pulling image %s: %v", image, err)
+	}
+	defer resp.Close()
+
+	_, _ = io.Copy(ioutil.Discard, resp)
+	return nil
+}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tilt-dev/clusterid"
@@ -490,6 +493,21 @@ func (c *fakeDockerClient) ContainerInspect(ctx context.Context, id string) (typ
 }
 
 func (d *fakeDockerClient) ContainerRemove(ctx context.Context, id string, options types.ContainerRemoveOptions) error {
+	return nil
+}
+
+func (d *fakeDockerClient) ImagePull(ctx context.Context, image string, options types.ImagePullOptions) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (d *fakeDockerClient) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+	return nil, nil
+}
+
+func (d *fakeDockerClient) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *specs.Platform, containerName string) (container.ContainerCreateCreatedBody, error) {
+	return container.ContainerCreateCreatedBody{}, nil
+}
+func (d *fakeDockerClient) ContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) error {
 	return nil
 }
 

--- a/pkg/cluster/docker.go
+++ b/pkg/cluster/docker.go
@@ -6,15 +6,15 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/tilt-dev/ctlptl/internal/dctr"
 	"github.com/tilt-dev/ctlptl/pkg/docker"
 )
 
 type dockerClient interface {
+	dctr.Client
 	IsLocalDockerEngine() bool
 	ServerVersion(ctx context.Context) (types.Version, error)
 	Info(ctx context.Context) (types.Info, error)
-	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
-	ContainerRemove(ctx context.Context, id string, options types.ContainerRemoveOptions) error
 	NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
 	NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/dockerclient:

bd8456af429ba21211c97f945e62cefead711abf (2022-04-01 14:58:05 -0400)
docker: use a docker API client instead of a subshell

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics