### PR TITLE
Revert "github: add dependabot config"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/dependabot:

9a680279c5bd7dad4ea1bfefe30388a6143f7baa (2022-04-05 10:46:47 -0400)
Revert "github: add dependabot config"
This reverts commit 33fe5dab73dd1f930e96367196bb6451a474583c.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics