### PR TITLE
cluster: make ctlptl handle 'minikube stop' and 'minikube pause' correctly

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -3,12 +3,15 @@ package exec
 import (
 	"context"
 	"os/exec"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 // A dummy package to help with mocking out exec.NewCommand
 
 type CmdRunner interface {
 	Run(ctx context.Context, cmd string, args ...string) error
+	RunIO(ctx context.Context, iostreams genericclioptions.IOStreams, cmd string, args ...string) error
 }
 
 type RealCmdRunner struct{}
@@ -16,6 +19,19 @@ type RealCmdRunner struct{}
 func (RealCmdRunner) Run(ctx context.Context, cmd string, args ...string) error {
 	// For some reason, ExitError only gets populated with Stderr if we call Output().
 	_, err := exec.CommandContext(ctx, cmd, args...).Output()
+
+	return err
+}
+
+func (RealCmdRunner) RunIO(ctx context.Context, iostreams genericclioptions.IOStreams, cmd string, args ...string) error {
+	c := exec.CommandContext(ctx, cmd, args...)
+	c.Stdin = iostreams.In
+	c.Stderr = iostreams.ErrOut
+	c.Stdout = iostreams.Out
+
+	// For some reason, ExitError only gets populated with Stderr if we call Output().
+	_, err := c.Output()
+
 	return err
 }
 
@@ -29,6 +45,12 @@ func NewFakeCmdRunner(handler func(argv []string)) *FakeCmdRunner {
 }
 
 func (f *FakeCmdRunner) Run(ctx context.Context, cmd string, args ...string) error {
+	f.LastArgs = append([]string{cmd}, args...)
+	f.handler(append([]string{cmd}, args...))
+	return nil
+}
+
+func (f *FakeCmdRunner) RunIO(ctx context.Context, iostreams genericclioptions.IOStreams, cmd string, args ...string) error {
 	f.LastArgs = append([]string{cmd}, args...)
 	f.handler(append([]string{cmd}, args...))
 	return nil

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tilt-dev/clusterid"
+	"github.com/tilt-dev/ctlptl/internal/exec"
 	"github.com/tilt-dev/ctlptl/pkg/api"
 	"github.com/tilt-dev/ctlptl/pkg/registry"
 	"github.com/tilt-dev/localregistry-go"
@@ -379,7 +380,7 @@ func newFixture(t *testing.T) *fixture {
 	d4m := &fakeD4MClient{docker: dockerClient}
 	dmachine := &dockerMachine{
 		dockerClient: dockerClient,
-		errOut:       os.Stderr,
+		iostreams:    genericclioptions.IOStreams{Out: os.Stdout, ErrOut: os.Stderr},
 		sleep:        func(d time.Duration) {},
 		d4m:          d4m,
 		os:           "darwin", // default to macos
@@ -428,6 +429,7 @@ func newFixture(t *testing.T) *fixture {
 	registryCtl := &fakeRegistryController{}
 	controller := &Controller{
 		iostreams:                   iostreams,
+		runner:                      exec.NewFakeCmdRunner(func(argv []string) {}),
 		admins:                      make(map[clusterid.Product]Admin),
 		config:                      *config,
 		configWriter:                configWriter,


### PR DESCRIPTION
Hello @milas, @lizzthabet,

Please review the following commits I made in branch nicks/issue211:

77ddf27adccba375f873fb811987586521fb7828 (2022-04-18 16:31:19 -0400)
cluster: make ctlptl handle 'minikube stop' and 'minikube pause' correctly
fixes https://github.com/tilt-dev/ctlptl/issues/211

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics