### PR TITLE
registry: add support for custom image

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -152,6 +152,14 @@ type Registry struct {
 	// that are tagged "app: k3d".
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 
+	// Image to use for registry container (optional).
+	//
+	// Can be used to provide an alternate image or use a different registry
+	// than Docker Hub.
+	//
+	// Defaults to `docker.io/library/registry:2`.
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+
 	// Most recently observed status of the registry.
 	// Populated by the system.
 	// Read-only.
@@ -190,6 +198,9 @@ type RegistryStatus struct {
 
 	// Labels attached to the running container.
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+
+	// Image for the running container.
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
 }
 
 // RegistryList is a list of Registrys.

--- a/pkg/cmd/create_registry.go
+++ b/pkg/cmd/create_registry.go
@@ -46,8 +46,12 @@ func (o *CreateRegistryOptions) Command() *cobra.Command {
 	cmd.SetOut(o.Out)
 	cmd.SetErr(o.ErrOut)
 	o.PrintFlags.AddFlags(cmd)
-	cmd.Flags().IntVar(&o.Registry.Port, "port", o.Registry.Port, "The port to expose the registry on host. If not specified, chooses a random port")
-	cmd.Flags().StringVar(&o.Registry.ListenAddress, "listen-address", o.Registry.ListenAddress, "The host's IP address to bind the container to. If not set defaults to 127.0.0.1")
+	cmd.Flags().IntVar(&o.Registry.Port, "port", o.Registry.Port,
+		"The port to expose the registry on host. If not specified, chooses a random port")
+	cmd.Flags().StringVar(&o.Registry.ListenAddress, "listen-address", o.Registry.ListenAddress,
+		"The host's IP address to bind the container to. If not set defaults to 127.0.0.1")
+	cmd.Flags().StringVar(&o.Registry.Image, "image", registry.DefaultRegistryImageRef,
+		"Registry image to use")
 
 	return cmd
 }

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -270,6 +271,11 @@ func (o *GetOptions) registriesAsTable(registries []api.Registry) runtime.Object
 			},
 		},
 	}
+
+	// sort chronologically newest -> oldest to match `docker ps` behavior
+	sort.SliceStable(registries, func(i, j int) bool {
+		return registries[i].Status.CreationTimestamp.After(registries[j].Status.CreationTimestamp.Time)
+	})
 
 	for _, registry := range registries {
 		age := "unknown"

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 )
 
+const ContainerLabelRole = "dev.tilt.ctlptl.role"
+
 // Checks whether the Docker daemon is running on a local machine.
 // Remote docker daemons will likely need a port forwarder to work properly.
 func IsLocalHost(dockerHost string) bool {


### PR DESCRIPTION
The most common use case here is for restricted environments that
don't have access to Docker hub. (That said, IMO it's better to
use the built-in `--registry-mirrors` option in Docker in this
situation.)

Currently, listing registries is currently done by looking for the
the ancestor image of `registry:2`, which won't work when using a
custom image. As a result, a new label is applied to all registries
created by `ctltptl`: `dev.tilt.ctlptl.role=registry`. The label key
uses the reverse DNS convention as suggested by Docker[1].

For both backwards compatibility (and interop with other tools that
create clusters such as `k3d`), we'll still search for registries by
`ancestor` as well. Additionally, the label will _not_ be applied to
any existing `ctlptl`-managed registries unless they're re-created
for another reason, as labels on containers are immutable, and there's
no compelling reason to forcibly re-create users' registries to add
the label.

Fixes #215.