### PR TITLE
cluster: add minikube-start-flags

### DIFF
--- a/hack/make-rules/generated.sh
+++ b/hack/make-rules/generated.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 REPO_ROOT=$(dirname $(dirname $(dirname "$0")))
 cd "${REPO_ROOT}"
 
+GOROOT="$(go env GOROOT)"
 deepcopy-gen \
    -i "./pkg/api" \
    -O zz_generated.deepcopy \

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -28,11 +28,7 @@ func (RealCmdRunner) RunIO(ctx context.Context, iostreams genericclioptions.IOSt
 	c.Stdin = iostreams.In
 	c.Stderr = iostreams.ErrOut
 	c.Stdout = iostreams.Out
-
-	// For some reason, ExitError only gets populated with Stderr if we call Output().
-	_, err := c.Output()
-
-	return err
+	return c.Run()
 }
 
 type FakeCmdRunner struct {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -112,6 +112,10 @@ type MinikubeCluster struct {
 	//
 	// kubelet.max-pods=500
 	ExtraConfigs []string `json:"extraConfigs,omitempty" yaml:"extraConfigs,omitempty"`
+
+	// Unstructured flags to pass to minikube on `minikube start`.
+	// These flags will be passed before all tilt-determined flags.
+	StartFlags []string `json:"startFlags,omitempty" yaml:"startFlags,omitempty"`
 }
 
 // ClusterList is a list of Clusters.

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -125,6 +125,11 @@ func (in *MinikubeCluster) DeepCopyInto(out *MinikubeCluster) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.StartFlags != nil {
+		in, out := &in.StartFlags, &out.StartFlags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/cluster/admin_minikube_test.go
+++ b/pkg/cluster/admin_minikube_test.go
@@ -1,0 +1,43 @@
+package cluster
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tilt-dev/ctlptl/internal/exec"
+	"github.com/tilt-dev/ctlptl/pkg/api"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func TestMinikubeStartFlags(t *testing.T) {
+	f := newMinikubeFixture()
+	ctx := context.Background()
+	err := f.a.Create(ctx, &api.Cluster{Name: "minikube", Minikube: &api.MinikubeCluster{StartFlags: []string{"--foo"}}}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"minikube", "start",
+		"--foo",
+		"-p", "minikube",
+		"--driver=docker",
+		"--container-runtime=containerd",
+		"--extra-config=kubelet.max-pods=500",
+	}, f.runner.LastArgs)
+}
+
+type minikubeFixture struct {
+	runner *exec.FakeCmdRunner
+	a      *minikubeAdmin
+}
+
+func newMinikubeFixture() *minikubeFixture {
+	dockerClient := &fakeDockerClient{ncpu: 1}
+	iostreams := genericclioptions.IOStreams{Out: os.Stdout, ErrOut: os.Stderr}
+	runner := exec.NewFakeCmdRunner(func(argv []string) {})
+	return &minikubeFixture{
+		runner: runner,
+		a:      newMinikubeAdmin(iostreams, dockerClient, runner),
+	}
+}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -256,7 +256,7 @@ func (c *Controller) admin(ctx context.Context, product clusterid.Product) (Admi
 	case clusterid.ProductK3D:
 		admin = newK3dAdmin(c.iostreams)
 	case clusterid.ProductMinikube:
-		admin = newMinikubeAdmin(c.iostreams, dockerClient)
+		admin = newMinikubeAdmin(c.iostreams, dockerClient, c.runner)
 	}
 
 	if product == "" {


### PR DESCRIPTION
Hello @nicksieger, @milas,

Please review the following commits I made in branch nicks/flags:

edd4876a47991d2f87ccea1f275cd475daf14dd4 (2022-04-20 16:02:16 -0400)
cluster: add minikube-start-flags
fixes https://github.com/tilt-dev/ctlptl/issues/86

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics