### PR TITLE
cmd: add "ctlptl delete --cascade=true" to delete the registry attached to a cluster.

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -363,9 +363,15 @@ func (c *Controller) populateLocalRegistryHosting(ctx context.Context, cluster *
 
 	// Let's try to find the registry corresponding to this cluster.
 	var port int
-	_, err = fmt.Sscanf(hosting.Host, "localhost:%d", &port)
-	if err != nil || port == 0 {
-		return err
+	for _, pattern := range []string{"localhost:%d", "127.0.0.1:%d"} {
+		_, _ = fmt.Sscanf(hosting.Host, pattern, &port)
+		if port != 0 {
+			break
+		}
+	}
+
+	if port == 0 {
+		return nil
 	}
 
 	registryCtl, err := c.registryController(ctx)

--- a/pkg/cmd/create_cluster_test.go
+++ b/pkg/cmd/create_cluster_test.go
@@ -22,18 +22,38 @@ func TestCreateCluster(t *testing.T) {
 	err := o.run(fcc, "kind")
 	require.NoError(t, err)
 	assert.Equal(t, "cluster.ctlptl.dev/kind-kind created\n", out.String())
-	assert.Equal(t, "kind-kind", fcc.lastCluster.Name)
+	assert.Equal(t, "kind-kind", fcc.lastApplyName)
 }
 
 type fakeClusterController struct {
-	lastCluster *api.Cluster
+	clusters       map[string]*api.Cluster
+	lastApplyName  string
+	lastDeleteName string
+	nextError      error
+}
+
+func (cd *fakeClusterController) Delete(ctx context.Context, name string) error {
+	if cd.nextError != nil {
+		return cd.nextError
+	}
+	cd.lastDeleteName = name
+	delete(cd.clusters, name)
+	return nil
 }
 
 func (cd *fakeClusterController) Apply(ctx context.Context, cluster *api.Cluster) (*api.Cluster, error) {
-	cd.lastCluster = cluster
+	cd.lastApplyName = cluster.Name
+	if cd.clusters == nil {
+		cd.clusters = make(map[string]*api.Cluster)
+	}
+	cd.clusters[cluster.Name] = cluster
 	return cluster, nil
 }
 
 func (cd *fakeClusterController) Get(ctx context.Context, name string) (*api.Cluster, error) {
+	cluster, ok := cd.clusters[name]
+	if ok {
+		return cluster, nil
+	}
 	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "ctlptl.dev", Resource: "clusters"}, name)
 }


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/cascade:

402a7a32590b57ec4c5e8db7310d2d8fd1b68a7f (2022-05-03 12:57:21 -0400)
cmd: add "ctlptl delete --cascade=true" to delete the registry attached to a cluster.
Fixes https://github.com/tilt-dev/ctlptl/issues/103

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics