### PR TITLE
cmd: normalize cluster name.

### DIFF
--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -112,7 +112,7 @@ func (o *GetOptions) Run(cmd *cobra.Command, args []string) {
 		}
 
 		if len(args) >= 2 {
-			resource, err = c.Get(ctx, args[1])
+			resource, err = normalizedGet(ctx, c, args[1])
 			if err != nil {
 				if errors.IsNotFound(err) && o.IgnoreNotFound {
 					os.Exit(0)

--- a/pkg/cmd/normalize.go
+++ b/pkg/cmd/normalize.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/tilt-dev/clusterid"
+	"github.com/tilt-dev/ctlptl/pkg/api"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+type clusterGetter interface {
+	Get(ctx context.Context, name string) (*api.Cluster, error)
+}
+
+// We create clusters like:
+// ctlptl create cluster kind
+// For most clusters, the name of the cluster will match the name of the product.
+// But for cases where they don't match, we want
+// `ctlptl delete cluster kind` to automatically map to `ctlptl delete cluster kind-kind`
+func normalizedGet(ctx context.Context, controller clusterGetter, name string) (*api.Cluster, error) {
+	cluster, err := controller.Get(ctx, name)
+	if err == nil {
+		return cluster, nil
+	}
+
+	if !errors.IsNotFound(err) {
+		return nil, err
+	}
+
+	origErr := err
+	retryName := ""
+	if name == string(clusterid.ProductKIND) {
+		retryName = clusterid.ProductKIND.DefaultClusterName()
+	} else if name == string(clusterid.ProductK3D) {
+		retryName = clusterid.ProductK3D.DefaultClusterName()
+	}
+
+	if retryName == "" {
+		return nil, origErr
+	}
+
+	cluster, err = controller.Get(ctx, retryName)
+	if err == nil {
+		return cluster, nil
+	}
+	return nil, origErr
+}


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/normalize:

ed00bea7a21f5aa8e198de54fdd78870852cea76 (2022-05-03 15:49:40 -0400)
cmd: normalize cluster name.
Now, 'ctlptl get cluster k3d' and 'ctlptl delete cluster k3d' will
work as expected.

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics