### PR TITLE
goreleaser: build and release arm64 images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,8 @@ jobs:
   release-dry-run:
     docker:
       - image: cimg/go:1.18
+    environment:
+      DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - checkout
       - setup_remote_docker:
@@ -85,6 +87,8 @@ jobs:
   release:
     docker:
       - image: cimg/go:1.18
+    environment:
+      DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.11
+          version: 20.10.14
       - run: make install
       - run: test/kind-cluster-network/e2e.sh
           
@@ -75,10 +75,10 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.6
+          version: 20.10.14
       - run: git fetch --tags
       - run: go install github.com/goreleaser/goreleaser@latest
-      - run: goreleaser --rm-dist --skip-publish --snapshot
+      - run: goreleaser --debug --rm-dist --skip-publish --snapshot
       - slack/notify-on-failure:
           only_for_branches: main
           
@@ -88,7 +88,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.6
+          version: 20.10.14
       - run: git fetch --tags
       - run: go install github.com/goreleaser/goreleaser@latest
       - run: ./hack/release.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,8 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.14
+      # https://discuss.circleci.com/t/arm-version-of-remote-docker/41624
+      - run: ssh remote-docker "sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support"
       - run: git fetch --tags
       - run: go install github.com/goreleaser/goreleaser@latest
       - run: goreleaser --debug --rm-dist --skip-publish --snapshot
@@ -93,6 +95,8 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.14
+      # https://discuss.circleci.com/t/arm-version-of-remote-docker/41624
+      - run: ssh remote-docker "sudo apt-get update; sudo apt-get install -y qemu-user-static binfmt-support"
       - run: git fetch --tags
       - run: go install github.com/goreleaser/goreleaser@latest
       - run: ./hack/release.sh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,20 +81,45 @@ dockers:
 - goos: linux
   goarch: amd64
   image_templates:
-    - "tiltdev/ctlptl"
-    - "tiltdev/ctlptl:{{ .Tag }}"
+    - "tiltdev/ctlptl:{{ .Tag }}-amd64"
   dockerfile: hack/Dockerfile
+  use: buildx
   build_flag_templates:
   - "--platform=linux/amd64"
+  - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+  - "--label=org.opencontainers.image.description={{ .ProjectName }}"
+  - "--label=org.opencontainers.image.url=https://github.com/tilt-dev/{{ .ProjectName }}"
+  - "--label=org.opencontainers.image.source=https://github.com/tilt-dev/{{ .ProjectName }}"
+  - "--label=org.opencontainers.image.version={{ .Version }}"
+  - "--label=org.opencontainers.image.created={{ .Timestamp }}"
+  - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+  - "--label=org.opencontainers.image.licenses=Apache-2.0"
 - goos: linux
   goarch: arm64
   goarm: ''
   image_templates:
-    - "tiltdev/ctlptl"
-    - "tiltdev/ctlptl:{{ .Tag }}"
+    - "tiltdev/ctlptl:{{ .Tag }}-arm64"
   dockerfile: hack/Dockerfile
+  use: buildx
   build_flag_templates:
   - "--platform=linux/arm64"
+  - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+  - "--label=org.opencontainers.image.description={{ .ProjectName }}"
+  - "--label=org.opencontainers.image.url=https://github.com/tilt-dev/{{ .ProjectName }}"
+  - "--label=org.opencontainers.image.source=https://github.com/tilt-dev/{{ .ProjectName }}"
+  - "--label=org.opencontainers.image.version={{ .Version }}"
+  - "--label=org.opencontainers.image.created={{ .Timestamp }}"
+  - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+  - "--label=org.opencontainers.image.licenses=Apache-2.0"
+docker_manifests:
+- name_template: tiltdev/{{ .ProjectName }}:{{ .Version }}
+  image_templates:
+  - tiltdev/{{ .ProjectName }}:{{ .Version }}-amd64
+  - tiltdev/{{ .ProjectName }}:{{ .Version }}-arm64
+- name_template: tiltdev/{{ .ProjectName }}:latest
+  image_templates:
+  - tiltdev/{{ .ProjectName }}:{{ .Version }}-amd64
+  - tiltdev/{{ .ProjectName }}:{{ .Version }}-arm64
 
   
 # Uncomment these lines if you want to experiment with other

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,10 +78,23 @@ scoop:
   description: "Making local Kubernetes clusters easy to set up and tear down"
   license: Apache-2.0
 dockers:
-- image_templates:
+- goos: linux
+  goarch: amd64
+  image_templates:
     - "tiltdev/ctlptl"
     - "tiltdev/ctlptl:{{ .Tag }}"
   dockerfile: hack/Dockerfile
+  build_flag_templates:
+  - "--platform=linux/amd64"
+- goos: linux
+  goarch: arm64
+  image_templates:
+    - "tiltdev/ctlptl"
+    - "tiltdev/ctlptl:{{ .Tag }}"
+  dockerfile: hack/Dockerfile
+  build_flag_templates:
+  - "--platform=linux/arm64"
+
   
 # Uncomment these lines if you want to experiment with other
 # parts of the release process without releasing new binaries.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -88,6 +88,7 @@ dockers:
   - "--platform=linux/amd64"
 - goos: linux
   goarch: arm64
+  goarm: ''
   image_templates:
     - "tiltdev/ctlptl"
     - "tiltdev/ctlptl:{{ .Tag }}"

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -39,7 +39,7 @@ RUN apt install -y apt-transport-https gnupg \
 # install Kind
 ENV KIND_VERSION=v0.14.0
 RUN set -exu \
-  && case $(uname -m) in aarch64) arch=arm64 ;; x64_64) arch=amd64 ;; *) arch=$(uname -m) ;; esac \
+  && case $(uname -m) in aarch64) arch=arm64 ;; x86_64) arch=amd64 ;; *) arch=$(uname -m) ;; esac \
   && curl -fLo ./kind-linux-$arch "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-$arch" \
   && chmod +x ./kind-linux-$arch \
   && mv ./kind-linux-$arch /usr/local/bin/kind

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -19,7 +19,7 @@ RUN apt update && apt install -y curl ca-certificates liblz4-tool rsync socat
 # Check https://download.docker.com/linux/static/stable/x86_64/ for latest versions
 ENV DOCKER_VERSION=20.10.15
 RUN set -exu \
-  && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
+  && DOCKER_URL="https://download.docker.com/linux/static/stable/$(uname -m)/docker-${DOCKER_VERSION}.tgz" \
   && echo Docker URL: $DOCKER_URL \
   && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
   && ls -lha /tmp/docker.tgz \
@@ -39,8 +39,9 @@ RUN apt install -y apt-transport-https gnupg \
 # install Kind
 ENV KIND_VERSION=v0.14.0
 RUN set -exu \
-  && curl -fLo ./kind-linux-amd64 "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64" \
-  && chmod +x ./kind-linux-amd64 \
-  && mv ./kind-linux-amd64 /usr/local/bin/kind
+  && case $(uname -m) in aarch64) arch=arm64 ;; x64_64) arch=amd64 ;; *) arch=$(uname -m) ;; esac \
+  && curl -fLo ./kind-linux-$arch "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-$arch" \
+  && chmod +x ./kind-linux-$arch \
+  && mv ./kind-linux-$arch /usr/local/bin/kind
 
 COPY ctlptl /usr/local/bin/ctlptl


### PR DESCRIPTION
Setup circle and goreleaser to build arm docker images via https://carlosbecker.com/posts/multi-platform-docker-images-goreleaser-gh-actions/