### PR TITLE
Fix Docker Desktop Kubernetes Reset

### DIFF
--- a/pkg/cluster/admin_minikube_test.go
+++ b/pkg/cluster/admin_minikube_test.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
 	"github.com/tilt-dev/ctlptl/internal/exec"
 	"github.com/tilt-dev/ctlptl/pkg/api"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 func TestMinikubeStartFlags(t *testing.T) {

--- a/pkg/cluster/docker_desktop.go
+++ b/pkg/cluster/docker_desktop.go
@@ -21,12 +21,13 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// Uses the DockerDesktop GUI protocol to control DockerDesktop.
+// Uses the DockerDesktop GUI+Backend protocols to control DockerDesktop.
 //
 // There isn't an off-the-shelf library or documented protocol we can use
 // for this, so we do the best we can.
 type DockerDesktopClient struct {
-	httpClient HTTPClient
+	guiClient     HTTPClient
+	backendClient HTTPClient
 }
 
 func NewDockerDesktopClient() (DockerDesktopClient, error) {
@@ -35,7 +36,7 @@ func NewDockerDesktopClient() (DockerDesktopClient, error) {
 		return DockerDesktopClient{}, err
 	}
 
-	httpClient := &http.Client{
+	guiClient := &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 				var lastErr error
@@ -54,8 +55,16 @@ func NewDockerDesktopClient() (DockerDesktopClient, error) {
 			},
 		},
 	}
+	backendClient := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return dialDockerBackend()
+			},
+		},
+	}
 	return DockerDesktopClient{
-		httpClient: httpClient,
+		guiClient:     guiClient,
+		backendClient: backendClient,
 	}, nil
 }
 
@@ -112,40 +121,26 @@ func (c DockerDesktopClient) Quit(ctx context.Context) error {
 func (c DockerDesktopClient) ResetCluster(ctx context.Context) error {
 	klog.V(7).Infof("POST /kubernetes/reset\n")
 
-	checkErrors := func(err error, statusCode int) error {
-		if err != nil {
-			return errors.Wrap(err, "reset docker-desktop kubernetes")
-		}
-		if statusCode != 0 && statusCode != http.StatusOK && statusCode != http.StatusCreated {
-			return fmt.Errorf("reset docker-desktop kubernetes: status code %d", statusCode)
-		}
-		return nil
-	}
-
 	req, err := http.NewRequest("POST", "http://localhost/kubernetes/reset", nil)
-	if err = checkErrors(err, 0); err != nil {
-		return err
+	if err != nil {
+		return errors.Wrap(err, "reset docker-desktop kubernetes")
 	}
 
 	req.Header.Add("Content-Type", "application/json")
-	resp, err := c.httpClient.Do(req)
-	defer resp.Body.Close()
-	if err = checkErrors(err, 0); err != nil {
-		return err
+	resp, err := c.guiClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "reset docker-desktop kubernetes")
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		resp.Body.Close()
-		backendClient := http.Client{
-			Transport: &http.Transport{
-				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-					return dialDockerBackend()
-				},
-			},
+		resp2, err := c.backendClient.Do(req)
+		if err != nil {
+			return errors.Wrap(err, "reset docker-desktop kubernetes")
 		}
-		resp, err = backendClient.Do(req)
-		if err = checkErrors(err, resp.StatusCode); err != nil {
-			return err
+		defer resp2.Body.Close()
+		if resp2.StatusCode != http.StatusOK && resp2.StatusCode != http.StatusCreated {
+			return fmt.Errorf("reset docker-desktop kubernetes: status code %d", resp2.StatusCode)
 		}
 	}
 	return nil
@@ -284,7 +279,7 @@ func (c DockerDesktopClient) writeSettings(ctx context.Context, settings map[str
 	}
 
 	req.Header.Add("Content-Type", "application/json")
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.guiClient.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "writing docker-desktop settings")
 	}
@@ -303,7 +298,7 @@ func (c DockerDesktopClient) settings(ctx context.Context) (map[string]interface
 		return nil, errors.Wrap(err, "reading docker-desktop settings")
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.guiClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to Docker Desktop. "+
 			"Please ensure Docker is installed and up to date.\n  (caused by: %v)", err)

--- a/pkg/cluster/docker_desktop_dial.go
+++ b/pkg/cluster/docker_desktop_dial.go
@@ -25,12 +25,12 @@ func dockerDesktopSocketPaths() ([]string, error) {
 			filepath.Join(homedir, "Library/Containers/com.docker.docker/Data/gui-api.sock"),
 
 			// Newer versions of docker desktop use this socket.
-			filepath.Join(homedir, "Library/Containers/com.docker.docker/Data/backend.native.sock"),
+			filepath.Join(homedir, "Library/Containers/com.docker.docker/Data/backend.sock"),
 		}, nil
 	case "linux":
 		return []string{
 			// Docker Desktop for Linux
-			filepath.Join(homedir, ".docker/desktop/backend.native.sock"),
+			filepath.Join(homedir, ".docker/desktop/backend.sock"),
 		}, nil
 	}
 	return nil, fmt.Errorf("Cannot find docker-desktop socket paths on %s", runtime.GOOS)

--- a/pkg/cluster/docker_desktop_dial.go
+++ b/pkg/cluster/docker_desktop_dial.go
@@ -21,11 +21,11 @@ func dockerDesktopSocketPaths() ([]string, error) {
 	switch runtime.GOOS {
 	case "darwin":
 		return []string{
-			// Older versions of docker desktop use this socket.
-			filepath.Join(homedir, "Library/Containers/com.docker.docker/Data/gui-api.sock"),
-
 			// Newer versions of docker desktop use this socket.
 			filepath.Join(homedir, "Library/Containers/com.docker.docker/Data/backend.sock"),
+
+			// Older versions of docker desktop use this socket.
+			filepath.Join(homedir, "Library/Containers/com.docker.docker/Data/gui-api.sock"),
 		}, nil
 	case "linux":
 		return []string{

--- a/pkg/cluster/docker_desktop_dial_windows.go
+++ b/pkg/cluster/docker_desktop_dial_windows.go
@@ -13,8 +13,8 @@ import (
 
 func dockerDesktopSocketPaths() ([]string, error) {
 	return []string{
+		`\\.\pipe\dockerBackendNativeApiServer`,
 		`\\.\pipe\dockerWebApiServer`,
-		`\\.\pipe\dockerBackendApiServer`,
 	}, nil
 }
 
@@ -30,4 +30,8 @@ func dialDockerDesktop(socketPath string) (net.Conn, error) {
 		return nil, err
 	}
 	return npipe.DialTimeout(socketPath, 2*time.Second)
+}
+
+func dialDockerBackend() (net.Conn, error) {
+	return dialDockerDesktop(`\\.\pipe\dockerBackendApiServer`)
 }

--- a/pkg/cluster/docker_desktop_dial_windows.go
+++ b/pkg/cluster/docker_desktop_dial_windows.go
@@ -14,7 +14,7 @@ import (
 func dockerDesktopSocketPaths() ([]string, error) {
 	return []string{
 		`\\.\pipe\dockerWebApiServer`,
-		`\\.\pipe\dockerBackendNativeApiServer`,
+		`\\.\pipe\dockerBackendApiServer`,
 	}, nil
 }
 

--- a/pkg/cluster/docker_desktop_test.go
+++ b/pkg/cluster/docker_desktop_test.go
@@ -240,7 +240,7 @@ type d4mFixture struct {
 func newD4MFixture(t *testing.T) *d4mFixture {
 	f := &d4mFixture{t: t}
 	f.settings = getSettingsJSON
-	f.d4m = &DockerDesktopClient{httpClient: f}
+	f.d4m = &DockerDesktopClient{guiClient: f}
 	return f
 }
 

--- a/pkg/cmd/create_cluster.go
+++ b/pkg/cmd/create_cluster.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/tilt-dev/clusterid"
+
 	"github.com/tilt-dev/ctlptl/pkg/api"
 	"github.com/tilt-dev/ctlptl/pkg/cluster"
 )

--- a/pkg/cmd/delete_test.go
+++ b/pkg/cmd/delete_test.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tilt-dev/ctlptl/pkg/api"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/tilt-dev/ctlptl/pkg/api"
 )
 
 func TestDeleteByName(t *testing.T) {

--- a/pkg/cmd/normalize.go
+++ b/pkg/cmd/normalize.go
@@ -4,8 +4,9 @@ import (
 	"context"
 
 	"github.com/tilt-dev/clusterid"
-	"github.com/tilt-dev/ctlptl/pkg/api"
 	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/tilt-dev/ctlptl/pkg/api"
 )
 
 type clusterGetter interface {


### PR DESCRIPTION
Changes backend socket/pipe to use non-native backend. Also some changes from `make fmt`.

After further review, it looks like /settings need to come from the GUI socket but [/kubernetes from the backend](/tilt-dev/ctlptl/pull/228#pullrequestreview-994116271) socket. 