### PR TITLE
circleci: move images to docker org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 
   e2e-remote-docker:
     docker:
-      - image: gcr.io/windmill-public-containers/ctlptl-e2e-ci
+      - image: docker/tilt-ctlptl-ci
     steps:
       - checkout
       - setup_remote_docker:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,6 +82,7 @@ dockers:
   goarch: amd64
   image_templates:
     - "tiltdev/ctlptl:{{ .Tag }}-amd64"
+    - "docker/tilt-ctlptl:{{ .Tag }}-amd64"
   dockerfile: hack/Dockerfile
   use: buildx
   build_flag_templates:
@@ -99,6 +100,7 @@ dockers:
   goarm: ''
   image_templates:
     - "tiltdev/ctlptl:{{ .Tag }}-arm64"
+    - "docker/tilt-ctlptl:{{ .Tag }}-arm64"
   dockerfile: hack/Dockerfile
   use: buildx
   build_flag_templates:
@@ -120,6 +122,14 @@ docker_manifests:
   image_templates:
   - tiltdev/{{ .ProjectName }}:{{ .Tag }}-amd64
   - tiltdev/{{ .ProjectName }}:{{ .Tag }}-arm64
+- name_template: docker/tilt-{{ .ProjectName }}:{{ .Tag }}
+  image_templates:
+  - docker/tilt-{{ .ProjectName }}:{{ .Tag }}-amd64
+  - docker/tilt-{{ .ProjectName }}:{{ .Tag }}-arm64
+- name_template: docker/tilt-{{ .ProjectName }}:latest
+  image_templates:
+  - docker/tilt-{{ .ProjectName }}:{{ .Tag }}-amd64
+  - docker/tilt-{{ .ProjectName }}:{{ .Tag }}-arm64
 
   
 # Uncomment these lines if you want to experiment with other

--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,5 @@ $(GOLANGCILINT):
 	(cd /; GO111MODULE=on GOPROXY="direct" GOSUMDB=off go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.30.0)
 
 publish-ci-image:
-	docker build -t gcr.io/windmill-public-containers/ctlptl-e2e-ci -f .circleci/Dockerfile .
-	docker push gcr.io/windmill-public-containers/ctlptl-e2e-ci
+	docker build -t docker/tilt-ctlptl-ci -f .circleci/Dockerfile .
+	docker push docker/tilt-ctlptl-ci


### PR DESCRIPTION
Hello @nicksieger,

Please review the following commits I made in branch nicks/images:

40929f3793bacaee073cb34dd0a5c33543454aef (2022-06-10 12:34:45 -0400)
circleci: move images to docker org

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics