### PR TITLE
cmd: fix a bug in the cascade flag

### DIFF
--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -252,20 +252,21 @@ func (o *DeleteOptions) cascadeResources(ctx context.Context, resources []runtim
 			}
 
 			if registryName != "" && !registryNames[registryName] {
+				registryNames[registryName] = true
 				result = append(result, &api.Registry{
 					TypeMeta: registry.TypeMeta(),
 					Name:     registryName,
 				})
-				registryNames[registryName] = true
 			}
+			result = append(result, r)
 
 		case *api.Registry:
-			if !registryNames[r.Name] {
-				registryNames[r.Name] = true
+			if registryNames[r.Name] {
 				continue
 			}
+			registryNames[r.Name] = true
+			result = append(result, r)
 		}
-		result = append(result, r)
 	}
 
 	return result, nil


### PR DESCRIPTION
Hello @nicksieger,

Please review the following commits I made in branch nicks/issue-243:

757849fc91d721d19254e1b1d38cdf53562c5f3d (2022-07-28 15:14:24 -0400)
cmd: fix a bug in the cascade flag
fixes https://github.com/tilt-dev/ctlptl/issues/243

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics