### PR TITLE
upgrade to go 1.19

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -9,7 +9,7 @@
 # Similar to the release image (which contains everything BUT the build
 # toolchain)
 
-FROM golang:1.18-buster
+FROM golang:1.19-buster
 
 RUN apt update && apt install -y curl ca-certificates liblz4-tool rsync socat
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     steps:
       - checkout
       - run: go get -v -t -d ./...
@@ -17,7 +17,7 @@ jobs:
 
   e2e-remote-docker:
     docker:
-      - image: docker/tilt-ctlptl-ci
+      - image: docker/tilt-ctlptl-ci@sha256:74e2dcb1a8abec971e2a6b616aae1bff8bb6d1abdc9d9c03b1a95f090952447f
     steps:
       - checkout
       - setup_remote_docker:
@@ -33,9 +33,9 @@ jobs:
       - kubernetes/install-kubectl
       - run: |
           set -ex
-          wget https://golang.org/dl/go1.18.linux-amd64.tar.gz
+          wget https://golang.org/dl/go1.19.linux-amd64.tar.gz
           sudo rm -fR /usr/local/go
-          sudo tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
+          sudo tar -C /usr/local -xzf go1.19.linux-amd64.tar.gz
       # We need a newer Docker version to work around a k3d/containerd bug.
       # https://github.com/rancher/k3d/issues/807
       - run: |
@@ -71,7 +71,7 @@ jobs:
           
   release-dry-run:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
@@ -88,7 +88,7 @@ jobs:
           
   release:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.19
     environment:
       DOCKER_CLI_EXPERIMENTAL: enabled
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tilt-dev/ctlptl
 
-go 1.18
+go 1.19
 
 require (
 	github.com/blang/semver/v4 v4.0.0


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/go119:

1e42f416d62a2a6fec082951d7840259a8919511 (2022-08-22 18:23:41 -0400)
upgrade to go 1.19
Signed-off-by: Nick Santos <nick.santos@docker.com>

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics