### PR TITLE
cluster: detect in-container docker and fix KIND kubeconfig

### DIFF
--- a/pkg/cluster/admin.go
+++ b/pkg/cluster/admin.go
@@ -19,3 +19,9 @@ type Admin interface {
 
 	Delete(ctx context.Context, config *api.Cluster) error
 }
+
+// An extension of cluster admin that indicates the cluster configuration can be
+// modified for use from inside containers.
+type AdminInContainer interface {
+	ModifyConfigInContainer(ctx context.Context, cluster *api.Cluster, containerID string, dockerClient dockerClient, configWriter configWriter) error
+}

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -9,6 +9,7 @@ import (
 type configWriter interface {
 	SetContext(name string) error
 	DeleteContext(name string) error
+	SetConfig(name, value string) error
 }
 
 type kubeconfigWriter struct {
@@ -24,6 +25,13 @@ func (w kubeconfigWriter) SetContext(name string) error {
 
 func (w kubeconfigWriter) DeleteContext(name string) error {
 	cmd := exec.Command("kubectl", "config", "delete-context", name)
+	cmd.Stdout = w.iostreams.Out
+	cmd.Stderr = w.iostreams.ErrOut
+	return cmd.Run()
+}
+
+func (w kubeconfigWriter) SetConfig(name, value string) error {
+	cmd := exec.Command("kubectl", "config", "set", name, value)
 	cmd.Stdout = w.iostreams.Out
 	cmd.Stderr = w.iostreams.ErrOut
 	return cmd.Run()

--- a/pkg/cluster/docker.go
+++ b/pkg/cluster/docker.go
@@ -2,9 +2,11 @@ package cluster
 
 import (
 	"context"
+	"os"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/pkg/stringid"
 
 	"github.com/tilt-dev/ctlptl/internal/dctr"
 )
@@ -15,4 +17,48 @@ type dockerClient interface {
 	Info(ctx context.Context) (types.Info, error)
 	NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
 	NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error
+}
+
+type detectInContainer interface {
+	insideContainer(ctx context.Context) string
+}
+
+// InsideContainer checks the current host and docker client to see if we are
+// running inside a container with a Docker-out-of-Docker-mounted socket. It
+// checks if:
+//
+//   - The effective DOCKER_HOST is `/var/run/docker.sock`
+//   - The hostname looks like a container "short id" and is a valid, running
+//     container
+//
+// Returns a non-empty string representing the container ID if inside a container.
+func insideContainer(ctx context.Context, client dockerClient) string {
+	// allows fake client to mock the result
+	if detect, ok := client.(detectInContainer); ok {
+		return detect.insideContainer(ctx)
+	}
+
+	if client.DaemonHost() != "unix:///var/run/docker.sock" {
+		return ""
+	}
+
+	containerID, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+
+	if !stringid.IsShortID(containerID) {
+		return ""
+	}
+
+	container, err := client.ContainerInspect(ctx, containerID)
+	if err != nil {
+		return ""
+	}
+
+	if !container.State.Running {
+		return ""
+	}
+
+	return containerID
 }


### PR DESCRIPTION
When ctlptl is run in a container, fix the KIND kubeconfig so ctlptl and other
containers can reach the apiserver on the kind network.

Fixes #251.

Signed-off-by: Nick Sieger <nick@nicksieger.com>
