### PR TITLE
cluster: handle containerd on minikube 1.27

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           sudo apt upgrade -y containerd.io
       - run: |
           set -ex
-          export MINIKUBE_VERSION=v1.25.0
+          export MINIKUBE_VERSION=v1.27.0
           curl -fLo ./minikube-linux-amd64 "https://github.com/kubernetes/minikube/releases/download/${MINIKUBE_VERSION}/minikube-linux-amd64"
           chmod +x ./minikube-linux-amd64
           sudo mv ./minikube-linux-amd64 /usr/local/bin/minikube


### PR DESCRIPTION
Hello @nicksieger,

Please review the following commits I made in branch nicks/issue239:

41bf3d94d3cff051e3d1ada4bb12f4c48e980abd (2022-09-16 12:16:28 -0400)
cluster: handle containerd on minikube 1.27
https://github.com/tilt-dev/ctlptl/issues/239

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics