### PR TITLE
registry: enable deletion by default

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -253,6 +253,7 @@ func (c *Controller) Apply(ctx context.Context, desired *api.Registry) (*api.Reg
 			Image:        desired.Image,
 			ExposedPorts: exposedPorts,
 			Labels:       c.labelConfigs(existing, desired),
+			Env:          []string{"REGISTRY_STORAGE_DELETE_ENABLED=true"},
 		},
 		&container.HostConfig{
 			RestartPolicy: container.RestartPolicy{Name: "always"},

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -253,6 +253,7 @@ func TestApplyLabels(t *testing.T) {
 		}, config.Labels)
 		assert.Equal(t, "kind-registry", config.Hostname)
 		assert.Equal(t, "docker.io/library/registry:2", config.Image)
+		assert.Equal(t, []string{"REGISTRY_STORAGE_DELETE_ENABLED=true"}, config.Env)
 	}
 }
 


### PR DESCRIPTION
Hello @nicksieger,

Please review the following commits I made in branch nicks/issue247:

1f6d5a6d6a1c2acb2873d2088e6edce1838cb2a6 (2022-09-16 14:31:12 -0400)
registry: enable deletion by default
fixes https://github.com/tilt-dev/ctlptl/issues/247

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics