### PR TITLE
Add `go install` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ scoop bucket add tilt-dev https://github.com/tilt-dev/scoop-bucket
 scoop install ctlptl
 ```
 
+### Go install
+
+```
+go install github.com/tilt-dev/ctlptl/cmd/ctlptl@latest
+```
+
 ### Alternative Options
 
 If automatic installers aren't your cup of tea, check out the [installation


### PR DESCRIPTION
At least in my small team, we all agree that `go install` is the easiest way to install command line tools.