### PR TITLE
Add env property on Registry

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -176,6 +176,11 @@ type Registry struct {
 	// that are tagged "app: k3d".
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 
+	// Environment vars to use for registry container (optional).
+	//
+	// Can be used to change some parameters likes REGISTRY_HTTP_ADDR, REGISTRY_PROXY_REMOTEURL
+	Env []string `json:"env,omitempty" yaml:"env,omitempty"`
+
 	// Image to use for registry container (optional).
 	//
 	// Can be used to provide an alternate image or use a different registry
@@ -222,6 +227,9 @@ type RegistryStatus struct {
 
 	// Labels attached to the running container.
 	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+
+	// Env attached to the running container.
+	Env []string `json:"env,omitempty" yaml:"env,omitempty"`
 
 	// Image for the running container.
 	Image string `json:"image,omitempty" yaml:"image,omitempty"`

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"regexp"
+	"reflect"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
@@ -132,6 +134,15 @@ func (c *Controller) List(ctx context.Context, options ListOptions) (*api.Regist
 		name := strings.TrimPrefix(container.Names[0], "/")
 		created := time.Unix(container.Created, 0)
 
+		inspect, err := c.dockerClient.ContainerInspect(ctx, container.ID)
+		if err != nil {
+			return nil, err
+		}
+		env := []string{}
+		if inspect.Config != nil {
+			env = inspect.Config.Env
+		}
+
 		netSummary := container.NetworkSettings
 		ipAddress := ""
 		networks := []string{}
@@ -163,6 +174,7 @@ func (c *Controller) List(ctx context.Context, options ListOptions) (*api.Regist
 				State:             container.State,
 				Labels:            container.Labels,
 				Image:             container.Image,
+				Env:               env,
 			},
 		}
 
@@ -218,6 +230,38 @@ func (c *Controller) Apply(ctx context.Context, desired *api.Registry) (*api.Reg
 			needsDelete = true
 		}
 	}
+
+	r := regexp.MustCompile("^(?P<key>[^=]+)=(?P<value>.*)")
+	desiredEnvs := make(map[string]string)
+	for _, value := range desired.Env {
+		m := r.FindStringSubmatch(value)
+		if m != nil {
+			k := m[r.SubexpIndex("key")]
+			v := m[r.SubexpIndex("value")]
+			if k != "PATH" {
+				desiredEnvs[k] = v
+			}
+		}
+	}
+	existingEnvs := make(map[string]string)
+	for _, value := range existing.Status.Env {
+		m := r.FindStringSubmatch(value)
+		if m != nil {
+			k := m[r.SubexpIndex("key")]
+			v := m[r.SubexpIndex("value")]
+			if k != "PATH" {
+				existingEnvs[k] = v
+			}
+		}
+	}
+	if _, ok := desiredEnvs["REGISTRY_STORAGE_DELETE_ENABLED"]; ! ok {
+		desiredEnvs["REGISTRY_STORAGE_DELETE_ENABLED"] = "true"
+		desired.Env = append(desired.Env, "REGISTRY_STORAGE_DELETE_ENABLED=true")
+	}
+	if eq := reflect.DeepEqual(desiredEnvs, existingEnvs); ! eq {
+		needsDelete = true
+	}
+
 	if needsDelete && existing.Name != "" {
 		err = c.Delete(ctx, existing.Name)
 		if err != nil {
@@ -253,7 +297,7 @@ func (c *Controller) Apply(ctx context.Context, desired *api.Registry) (*api.Reg
 			Image:        desired.Image,
 			ExposedPorts: exposedPorts,
 			Labels:       c.labelConfigs(existing, desired),
-			Env:          []string{"REGISTRY_STORAGE_DELETE_ENABLED=true"},
+			Env:          desired.Env,
 		},
 		&container.HostConfig{
 			RestartPolicy: container.RestartPolicy{Name: "always"},

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -138,11 +138,7 @@ func (c *Controller) List(ctx context.Context, options ListOptions) (*api.Regist
 		if err != nil {
 			return nil, err
 		}
-		env := []string{}
-		if inspect.Config != nil {
-			env = inspect.Config.Env
-		}
-
+		env := inspect.Config.Env
 		netSummary := container.NetworkSettings
 		ipAddress := ""
 		networks := []string{}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -343,7 +343,7 @@ func TestCustomEnv(t *testing.T) {
 	}
 
 	// ensure stable w/o image change
-	registry, err := f.c.Apply(context.Background(), &api.Registry{
+	_, err := f.c.Apply(context.Background(), &api.Registry{
 		TypeMeta: typeMeta,
 		Name:     "kind-registry",
 		Image:    "registry:2",
@@ -353,7 +353,7 @@ func TestCustomEnv(t *testing.T) {
 	}
 
 	// change env, should be (re)created
-	registry, err = f.c.Apply(context.Background(), &api.Registry{
+	registry, err := f.c.Apply(context.Background(), &api.Registry{
 		TypeMeta: typeMeta,
 		Name:     "kind-registry",
 		Image:    "registry:2",

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -138,7 +138,7 @@ func TestListRegistries(t *testing.T) {
 			State:             "running",
 			Labels:            map[string]string{"dev.tilt.ctlptl.role": "registry"},
 			Image:             "registry:2",
-			Env:							 []string{},
+			Env:							 []string{"REGISTRY_STORAGE_DELETE_ENABLED=true","PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 		},
 	}, list.Items[0])
 	assert.Equal(t, api.Registry{
@@ -156,7 +156,7 @@ func TestListRegistries(t *testing.T) {
 			State:             "running",
 			Labels:            map[string]string{"dev.tilt.ctlptl.role": "registry"},
 			Image:             "fake.tilt.dev/my-registry-image:latest",
-			Env:							 []string{},
+			Env:							 []string{"REGISTRY_STORAGE_DELETE_ENABLED=true","PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 		},
 	}, list.Items[1])
 	assert.Equal(t, api.Registry{
@@ -173,7 +173,7 @@ func TestListRegistries(t *testing.T) {
 			ContainerID:       "d62f2587ff7b03858f144d3cf83c789578a6d6403f8b82a459ab4e317917cd42",
 			State:             "running",
 			Image:             "registry:2",
-			Env:							 []string{},
+			Env:							 []string{"REGISTRY_STORAGE_DELETE_ENABLED=true","PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 		},
 	}, list.Items[2])
 }
@@ -201,7 +201,7 @@ func TestGetRegistry(t *testing.T) {
 			State:             "running",
 			Labels:            map[string]string{"dev.tilt.ctlptl.role": "registry"},
 			Image:             "registry:2",
-			Env:							 []string{},
+			Env:							 []string{"REGISTRY_STORAGE_DELETE_ENABLED=true","PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 		},
 	}, registry)
 }
@@ -361,6 +361,33 @@ func (d *fakeDocker) ContainerInspect(ctx context.Context, containerID string) (
 					State: &types.ContainerState{
 						Running: c.State == "running",
 					},
+				},
+				Config: &container.Config{
+					Hostname:"test", 
+					Domainname:"", 
+					User:"", 
+					AttachStdin:false, 
+					AttachStdout:false, 
+					AttachStderr:false, 
+					// ExposedPorts:nat.PortSet{"5000/tcp":struct {}{}}, 
+					Tty:false, 
+					OpenStdin:false, 
+					StdinOnce:false, 
+					Env:[]string{"REGISTRY_STORAGE_DELETE_ENABLED=true", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}, 
+					Cmd:[]string{"/etc/docker/registry/config.yml"}, 
+					Healthcheck:(*container.HealthConfig)(nil), 
+					ArgsEscaped:false, 
+					Image:"docker.io/library/registry:2", 
+					Volumes:map[string]struct {}{"/var/lib/registry":struct {}{}}, 
+					WorkingDir:"", 
+					Entrypoint:[]string{"/entrypoint.sh"}, 
+					NetworkDisabled:false, 
+					MacAddress:"", 
+					OnBuild:[]string(nil), 
+					Labels:map[string]string{"dev.tilt.ctlptl.role":"registry"}, 
+					StopSignal:"", 
+					StopTimeout:(*int)(nil), 
+					Shell:[]string(nil),
 				},
 			}, nil
 		}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -138,6 +138,7 @@ func TestListRegistries(t *testing.T) {
 			State:             "running",
 			Labels:            map[string]string{"dev.tilt.ctlptl.role": "registry"},
 			Image:             "registry:2",
+			Env:							 []string{},
 		},
 	}, list.Items[0])
 	assert.Equal(t, api.Registry{
@@ -155,6 +156,7 @@ func TestListRegistries(t *testing.T) {
 			State:             "running",
 			Labels:            map[string]string{"dev.tilt.ctlptl.role": "registry"},
 			Image:             "fake.tilt.dev/my-registry-image:latest",
+			Env:							 []string{},
 		},
 	}, list.Items[1])
 	assert.Equal(t, api.Registry{
@@ -171,6 +173,7 @@ func TestListRegistries(t *testing.T) {
 			ContainerID:       "d62f2587ff7b03858f144d3cf83c789578a6d6403f8b82a459ab4e317917cd42",
 			State:             "running",
 			Image:             "registry:2",
+			Env:							 []string{},
 		},
 	}, list.Items[2])
 }
@@ -198,6 +201,7 @@ func TestGetRegistry(t *testing.T) {
 			State:             "running",
 			Labels:            map[string]string{"dev.tilt.ctlptl.role": "registry"},
 			Image:             "registry:2",
+			Env:							 []string{},
 		},
 	}, registry)
 }


### PR DESCRIPTION
Acutally it's not possible to manage env vars of container registry.

Please let'me override registry configuration : https://docs.docker.com/registry/configuration/

A use case, inspirated by following post : https://maelvls.dev/docker-proxy-registry-kind/ is to declare a registry as a docker proxy for kind.

---
Create network, proxy and cluster; attach proxy to the network :
```
export KIND_EXPERIMENTAL_DOCKER_NETWORK=cluster
docker network create --scope local --driver bridge --subnet 10.20.0.0/16 --gateway 10.20.0.1 $KIND_EXPERIMENTAL_DOCKER_NETWORK
ctlptl apply -f /dev/stdin <<EOF                                                                                                                          
apiVersion: ctlptl.dev/v1alpha1
kind: Registry
name: proxy-docker-hub
env:
- REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io
---
apiVersion: ctlptl.dev/v1alpha1
kind: Cluster
product: kind
kubernetesVersion: "1.26"
kindV1Alpha4Cluster:
  name: $KIND_EXPERIMENTAL_DOCKER_NETWORK
  featureGates:
    PodSecurity: true
  containerdConfigPatches:
  - |-
    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
      endpoint = ["http://proxy-docker-hub:5000"]
  nodes:
  -   role: control-plane
EOF
docker network connect $KIND_EXPERIMENTAL_DOCKER_NETWORK proxy-docker-hub
```
---
Pull an image inside cluster :
```
docker exec -it $KIND_EXPERIMENTAL_DOCKER_NETWORK-control-plane crictl pull docker.io/library/alpine:3.9.6
```
---
Check proxy's logs :
```
docker logs -f proxy-docker-hub
```
---
![proxy](https://user-images.githubusercontent.com/13408634/221183635-5365f7ae-59b6-4c69-9e8a-9087aaf5b027.gif)

