### PR TITLE
cluster: report errors on the status field

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -94,6 +94,9 @@ type ClusterStatus struct {
 	// v1.18.10-gke.601
 	// v1.19.3-34+fa32ff1c160058
 	KubernetesVersion string `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
+
+	// Populated when we encounter an error reading the cluster status.
+	Error string `json:"error,omitempty"`
 }
 
 // MinikubeCluster describes minikube-specific options for starting a cluster.

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -181,6 +181,11 @@ func (in *Registry) DeepCopyInto(out *Registry) {
 			(*out)[key] = val
 		}
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	in.Status.DeepCopyInto(&out.Status)
 	return
 }
@@ -250,6 +255,11 @@ func (in *RegistryStatus) DeepCopyInto(out *RegistryStatus) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -75,6 +75,15 @@ func TestClusterList(t *testing.T) {
 	assert.Equal(t, "microk8s", clusters.Items[1].Name)
 }
 
+func TestClusterStatusError(t *testing.T) {
+	c := newFakeController(t)
+	clusters, err := c.List(context.Background(), ListOptions{})
+	assert.NoError(t, err)
+	require.Equal(t, 2, len(clusters.Items))
+	assert.Equal(t, "reading status: not started", clusters.Items[0].Status.Error)
+	assert.Equal(t, "", clusters.Items[1].Status.Error)
+}
+
 // Make sure that an empty config doesn't confuse ctlptl.
 func TestClusterListEmptyConfig(t *testing.T) {
 	c := newFakeController(t)


### PR DESCRIPTION
i've recently changed how i'm logged into clusters so that i get auto-logged out aggressively. So there's often a bunch of clusters that i have contexts for but where healthchecks will fail. this is ok! but let's report it.