### PR TITLE
cluster: always run 'k3d delete' before 'k3d create' to wipe out any …

### DIFF
--- a/pkg/cluster/admin.go
+++ b/pkg/cluster/admin.go
@@ -12,6 +12,11 @@ import (
 // independent of the configuration of the machine it's running on.
 type Admin interface {
 	EnsureInstalled(ctx context.Context) error
+
+	// Create a new cluster.
+	//
+	// Make a best effort attempt to delete any resources that might block creation
+	// of the cluster.
 	Create(ctx context.Context, desired *api.Cluster, registry *api.Registry) error
 
 	// Infers the LocalRegistryHosting that this admin will try to configure.

--- a/pkg/cluster/admin_k3d.go
+++ b/pkg/cluster/admin_k3d.go
@@ -66,6 +66,10 @@ func (a *k3dAdmin) Create(ctx context.Context, desired *api.Cluster, registry *a
 		return errors.Wrap(err, "creating k3d cluster")
 	}
 
+	// Delete any orphaned cluster resources, ignoring any errors.
+	// This can happen if the cluster exists but has been removed from the kubeconfig.
+	_ = a.Delete(ctx, desired)
+
 	if k3dV.LT(v5_3) {
 		// 5.2 and below
 		args := []string{"cluster", "create", k3dConfig.Name}


### PR DESCRIPTION
…old clusters