### PR TITLE
docker: pass credentials to image pull

### DIFF
--- a/internal/dctr/run.go
+++ b/internal/dctr/run.go
@@ -7,11 +7,15 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	cliflags "github.com/docker/cli/cli/flags"
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
+	registrytypes "github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/registry"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -26,9 +30,38 @@ type Client interface {
 	ContainerRemove(ctx context.Context, id string, options types.ContainerRemoveOptions) error
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *specs.Platform, containerName string) (container.CreateResponse, error)
 	ContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) error
+
+	ServerVersion(ctx context.Context) (types.Version, error)
+	Info(ctx context.Context) (types.Info, error)
+	NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
+	NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error
 }
 
-func NewAPIClient(streams genericclioptions.IOStreams) (client.APIClient, error) {
+type CLI interface {
+	Client() Client
+	AuthInfo(ctx context.Context, repoInfo *registry.RepositoryInfo, cmdName string) (string, types.RequestPrivilegeFunc, error)
+}
+
+type realCLI struct {
+	cli *command.DockerCli
+}
+
+func (c *realCLI) Client() Client {
+	return c.cli.Client()
+}
+
+func (c *realCLI) AuthInfo(ctx context.Context, repoInfo *registry.RepositoryInfo, cmdName string) (string, types.RequestPrivilegeFunc, error) {
+	authConfig := command.ResolveAuthConfig(ctx, c.cli, repoInfo.Index)
+	requestPrivilege := command.RegistryAuthenticationPrivilegedFunc(c.cli, repoInfo.Index, cmdName)
+
+	auth, err := registrytypes.EncodeAuthConfig(authConfig)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "authInfo#EncodeAuthToBase64")
+	}
+	return auth, requestPrivilege, nil
+}
+
+func NewCLI(streams genericclioptions.IOStreams) (CLI, error) {
 	dockerCli, err := command.NewDockerCli(
 		command.WithOutputStream(streams.Out),
 		command.WithErrorStream(streams.ErrOut))
@@ -51,7 +84,15 @@ func NewAPIClient(streams genericclioptions.IOStreams) (client.APIClient, error)
 	if endpoint.Host == "" {
 		return nil, fmt.Errorf("initializing docker client: no valid endpoint")
 	}
-	return dockerCli.Client(), nil
+	return &realCLI{cli: dockerCli}, nil
+}
+
+func NewAPIClient(streams genericclioptions.IOStreams) (Client, error) {
+	cli, err := NewCLI(streams)
+	if err != nil {
+		return nil, err
+	}
+	return cli.Client(), nil
 }
 
 // A simplified remove-container-if-necessary helper.
@@ -73,7 +114,8 @@ func RemoveIfNecessary(ctx context.Context, c Client, name string) error {
 }
 
 // A simplified run-container-and-detach helper for background support containers (like socat and the registry).
-func Run(ctx context.Context, c Client, name string, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig) error {
+func Run(ctx context.Context, cli CLI, name string, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig) error {
+	c := cli.Client()
 
 	ctr, err := c.ContainerInspect(ctx, name)
 	if err == nil && (ctr.ContainerJSONBase != nil && ctr.State.Running) {
@@ -95,7 +137,7 @@ func Run(ctx context.Context, c Client, name string, config *container.Config, h
 			return fmt.Errorf("creating %s: %v", name, err)
 		}
 
-		err := pull(ctx, c, config.Image)
+		err := pull(ctx, cli, config.Image)
 		if err != nil {
 			return fmt.Errorf("pulling image %s: %v", config.Image, err)
 		}
@@ -114,8 +156,28 @@ func Run(ctx context.Context, c Client, name string, config *container.Config, h
 	return nil
 }
 
-func pull(ctx context.Context, c Client, image string) error {
-	resp, err := c.ImagePull(ctx, image, types.ImagePullOptions{})
+func pull(ctx context.Context, cli CLI, image string) error {
+	c := cli.Client()
+
+	ref, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return fmt.Errorf("could not parse image %q: %v", image, err)
+	}
+
+	repoInfo, err := registry.ParseRepositoryInfo(ref)
+	if err != nil {
+		return fmt.Errorf("could not parse registry for %q: %v", image, err)
+	}
+
+	encodedAuth, requestPrivilege, err := cli.AuthInfo(ctx, repoInfo, "pull")
+	if err != nil {
+		return fmt.Errorf("could not authenticate: %v", err)
+	}
+
+	resp, err := c.ImagePull(ctx, image, types.ImagePullOptions{
+		RegistryAuth:  encodedAuth,
+		PrivilegeFunc: requestPrivilege,
+	})
 	if err != nil {
 		return fmt.Errorf("pulling image %s: %v", image, err)
 	}

--- a/internal/socat/socat.go
+++ b/internal/socat/socat.go
@@ -19,11 +19,11 @@ import (
 const serviceName = "ctlptl-portforward-service"
 
 type Controller struct {
-	client dctr.Client
+	cli dctr.CLI
 }
 
-func NewController(client dctr.Client) *Controller {
-	return &Controller{client: client}
+func NewController(cli dctr.CLI) *Controller {
+	return &Controller{cli: cli}
 }
 
 // Connect a port on the local machine to a port on a remote docker machine.
@@ -41,7 +41,7 @@ func (c *Controller) ConnectRemoteDockerPort(ctx context.Context, port int) erro
 func (c *Controller) StartRemotePortforwarder(ctx context.Context) error {
 	return dctr.Run(
 		ctx,
-		c.client,
+		c.cli,
 		serviceName,
 		&container.Config{
 			Hostname:   serviceName,

--- a/pkg/cluster/admin.go
+++ b/pkg/cluster/admin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/tilt-dev/localregistry-go"
 
+	"github.com/tilt-dev/ctlptl/internal/dctr"
 	"github.com/tilt-dev/ctlptl/pkg/api"
 )
 
@@ -28,5 +29,5 @@ type Admin interface {
 // An extension of cluster admin that indicates the cluster configuration can be
 // modified for use from inside containers.
 type AdminInContainer interface {
-	ModifyConfigInContainer(ctx context.Context, cluster *api.Cluster, containerID string, dockerClient dockerClient, configWriter configWriter) error
+	ModifyConfigInContainer(ctx context.Context, cluster *api.Cluster, containerID string, dockerClient dctr.Client, configWriter configWriter) error
 }

--- a/pkg/cluster/admin_kind.go
+++ b/pkg/cluster/admin_kind.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 
+	"github.com/tilt-dev/ctlptl/internal/dctr"
 	"github.com/tilt-dev/ctlptl/pkg/api"
 )
 
@@ -33,10 +34,10 @@ func kindNetworkName() string {
 // once the underlying machine has been setup.
 type kindAdmin struct {
 	iostreams    genericclioptions.IOStreams
-	dockerClient dockerClient
+	dockerClient dctr.Client
 }
 
-func newKindAdmin(iostreams genericclioptions.IOStreams, dockerClient dockerClient) *kindAdmin {
+func newKindAdmin(iostreams genericclioptions.IOStreams, dockerClient dctr.Client) *kindAdmin {
 	return &kindAdmin{
 		iostreams:    iostreams,
 		dockerClient: dockerClient,
@@ -206,7 +207,7 @@ func (a *kindAdmin) Delete(ctx context.Context, config *api.Cluster) error {
 	return nil
 }
 
-func (a *kindAdmin) ModifyConfigInContainer(ctx context.Context, cluster *api.Cluster, containerID string, dockerClient dockerClient, configWriter configWriter) error {
+func (a *kindAdmin) ModifyConfigInContainer(ctx context.Context, cluster *api.Cluster, containerID string, dockerClient dctr.Client, configWriter configWriter) error {
 	err := dockerClient.NetworkConnect(ctx, kindNetworkName(), containerID, nil)
 	if err != nil {
 		if !errdefs.IsForbidden(err) || !strings.Contains(err.Error(), "already exists") {

--- a/pkg/cluster/admin_minikube.go
+++ b/pkg/cluster/admin_minikube.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog/v2"
 
+	"github.com/tilt-dev/ctlptl/internal/dctr"
 	cexec "github.com/tilt-dev/ctlptl/internal/exec"
 	"github.com/tilt-dev/ctlptl/pkg/api"
 )
@@ -28,10 +29,10 @@ var v1_27 = semver.MustParse("1.27.0")
 type minikubeAdmin struct {
 	iostreams    genericclioptions.IOStreams
 	runner       cexec.CmdRunner
-	dockerClient dockerClient
+	dockerClient dctr.Client
 }
 
-func newMinikubeAdmin(iostreams genericclioptions.IOStreams, dockerClient dockerClient, runner cexec.CmdRunner) *minikubeAdmin {
+func newMinikubeAdmin(iostreams genericclioptions.IOStreams, dockerClient dctr.Client, runner cexec.CmdRunner) *minikubeAdmin {
 	return &minikubeAdmin{
 		iostreams:    iostreams,
 		dockerClient: dockerClient,

--- a/pkg/cluster/docker.go
+++ b/pkg/cluster/docker.go
@@ -4,20 +4,9 @@ import (
 	"context"
 	"os"
 
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/pkg/stringid"
-
 	"github.com/tilt-dev/ctlptl/internal/dctr"
 )
-
-type dockerClient interface {
-	dctr.Client
-	ServerVersion(ctx context.Context) (types.Version, error)
-	Info(ctx context.Context) (types.Info, error)
-	NetworkConnect(ctx context.Context, networkID, containerID string, config *network.EndpointSettings) error
-	NetworkDisconnect(ctx context.Context, networkID, containerID string, force bool) error
-}
 
 type detectInContainer interface {
 	insideContainer(ctx context.Context) string
@@ -32,7 +21,7 @@ type detectInContainer interface {
 //     container
 //
 // Returns a non-empty string representing the container ID if inside a container.
-func insideContainer(ctx context.Context, client dockerClient) string {
+func insideContainer(ctx context.Context, client dctr.Client) string {
 	// allows fake client to mock the result
 	if detect, ok := client.(detectInContainer); ok {
 		return detect.insideContainer(ctx)

--- a/pkg/cluster/machine.go
+++ b/pkg/cluster/machine.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	klog "k8s.io/klog/v2"
 
+	"github.com/tilt-dev/ctlptl/internal/dctr"
 	cexec "github.com/tilt-dev/ctlptl/internal/exec"
 	"github.com/tilt-dev/ctlptl/pkg/api"
 	"github.com/tilt-dev/ctlptl/pkg/docker"
@@ -58,13 +59,13 @@ type d4mClient interface {
 
 type dockerMachine struct {
 	iostreams    genericclioptions.IOStreams
-	dockerClient dockerClient
+	dockerClient dctr.Client
 	sleep        sleeper
 	d4m          d4mClient
 	os           string
 }
 
-func NewDockerMachine(ctx context.Context, client dockerClient, iostreams genericclioptions.IOStreams) (*dockerMachine, error) {
+func NewDockerMachine(ctx context.Context, client dctr.Client, iostreams genericclioptions.IOStreams) (*dockerMachine, error) {
 	d4m, err := NewDockerDesktopClient()
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/socat.go
+++ b/pkg/cmd/socat.go
@@ -39,13 +39,13 @@ func connectRemoteDocker(cmd *cobra.Command, args []string) {
 
 	ctx := context.Background()
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	dockerAPI, err := dctr.NewAPIClient(streams)
+	dockerCLI, err := dctr.NewCLI(streams)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "connect-remote-docker: %v\n", err)
 		os.Exit(1)
 	}
 
-	c := socat.NewController(dockerAPI)
+	c := socat.NewController(dockerCLI)
 	err = c.ConnectRemoteDockerPort(ctx, port)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "connect-remote-docker: %v\n", err)


### PR DESCRIPTION
this was mainly a yak shave, since the credentials come from the CLI rather than the API client.

fixes https://github.com/tilt-dev/ctlptl/issues/303