### PR TITLE
dockerfile: update how we install kubectl, docker clis

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -13,27 +13,26 @@ FROM golang:1.21-bookworm
 
 RUN apt update && apt install -y curl ca-certificates liblz4-tool rsync socat gpg
 
-# Install docker
-# Adapted from https://github.com/circleci/circleci-images/blob/staging/shared/images/Dockerfile-basic.template
-# Check https://download.docker.com/linux/static/stable/x86_64/ for latest versions
-ENV DOCKER_VERSION=24.0.5
-RUN install -m 0755 -d /etc/apt/keyrings \
-    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
-    && chmod a+r /etc/apt/keyrings/docker.gpg \
-    && echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
-       "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
-       tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-RUN apt update && apt install -y docker-ce-cli docker-buildx-plugin \
-  && which docker \
-  && (docker version || true)
+# Install docker CLI
+RUN set -exu \
+  # Add Docker's official GPG key:
+  && install -m 0755 -d /etc/apt/keyrings \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+  && chmod a+r /etc/apt/keyrings/docker.asc \
+  # Add the repository to Apt sources: 
+  && echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null \
+  && apt update \
+  && apt install -y docker-ce-cli=5:25.0.3-1~debian.12~bookworm docker-buildx-plugin
 
 # Install kubectl client
-RUN apt install -y apt-transport-https gnupg \
-  && curl -fsS https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
-  && touch /etc/apt/sources.list.d/kubernetes.list \
-  && echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list \
-  && apt update && apt install -y kubectl
+ENV KUBECTL_VERSION=v1.29.1
+RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+    && curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" \
+    && echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 # install Kind
 ENV KIND_VERSION=v0.22.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 
   e2e-remote-docker:
     docker:
-      - image: docker/tilt-ctlptl-ci@sha256:e388eaf36b098d3d7a35fc2c173d70acfc544e72c40058741eed34e53853a009
+      - image: docker/tilt-ctlptl-ci@sha256:3768fefdc7ede6e54b1aaedc3a36c32c98a003b546de2fa4f6dff69f1a0fcad5
     steps:
       - checkout
       - setup_remote_docker
@@ -61,8 +61,6 @@ jobs:
   release-dry-run:
     docker:
       - image: golang:1.21-bookworm
-    environment:
-      DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - checkout
       - setup_remote_docker
@@ -84,7 +82,7 @@ jobs:
             "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
             $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
           apt-get update
-          apt-get install -y docker-ce docker-ce-cli containerd.io
+          apt-get install -y docker-ce-cli docker-buildx-plugin
           docker --version
           rm -rf /var/lib/apt/lists/*
           
@@ -96,8 +94,6 @@ jobs:
   release:
     docker:
       - image: golang:1.21-bookworm
-    environment:
-      DOCKER_CLI_EXPERIMENTAL: enabled
     steps:
       - checkout
       - setup_remote_docker
@@ -119,7 +115,7 @@ jobs:
             "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
             $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
           apt-get update
-          apt-get install -y docker-ce docker-ce-cli containerd.io
+          apt-get install -y docker-ce-cli docker-buildx-plugin
           docker --version
           rm -rf /var/lib/apt/lists/*
           

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -14,31 +14,30 @@ FROM debian:bookworm-slim
 
 RUN apt update && apt install -y curl ca-certificates liblz4-tool rsync socat
 
-# Install docker
-# Adapted from https://github.com/circleci/circleci-images/blob/staging/shared/images/Dockerfile-basic.template
-# Check https://download.docker.com/linux/static/stable/x86_64/ for latest versions
-ENV DOCKER_VERSION=20.10.17
+# Install docker CLI
 RUN set -exu \
-  && DOCKER_URL="https://download.docker.com/linux/static/stable/$(uname -m)/docker-${DOCKER_VERSION}.tgz" \
-  && echo Docker URL: $DOCKER_URL \
-  && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
-  && ls -lha /tmp/docker.tgz \
-  && tar -xz -C /tmp -f /tmp/docker.tgz \
-  && mv /tmp/docker/* /usr/bin \
-  && rm -rf /tmp/docker /tmp/docker.tgz \
-  && which docker \
-  && (docker version || true)
+  # Add Docker's official GPG key:
+  && install -m 0755 -d /etc/apt/keyrings \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+  && chmod a+r /etc/apt/keyrings/docker.asc \
+  # Add the repository to Apt sources: 
+  && echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null \
+  && apt update \
+  && apt install -y docker-ce-cli=5:25.0.3-1~debian.12~bookworm 
 
 # Install kubectl client
-RUN apt install -y apt-transport-https gnupg \
-  && curl -fsS https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
-  && touch /etc/apt/sources.list.d/kubernetes.list \
-  && echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list \
-  && apt update && apt install -y kubectl
+ARG TARGETARCH
+ENV KUBECTL_VERSION=v1.29.1
+RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
+    && curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl.sha256" \
+    && echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check \
+    && install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 # Install Kind
 ENV KIND_VERSION=v0.20.0
-ARG TARGETARCH
 RUN set -exu \
   && KIND_URL="https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-$TARGETARCH" \
   && curl --silent --show-error --location --fail --retry 3 --output ./kind-linux-$TARGETARCH "$KIND_URL" \


### PR DESCRIPTION
looks like the kubernetes repos broke
this installation path, see this thread:

https://forum.linuxfoundation.org/discussion/864693/the-repository-http-apt-kubernetes-io-kubernetes-xenial-release-does-not-have-a-release-file
Signed-off-by: Nick Santos <nick.santos@docker.com>
