### PR TITLE
go: update to 1.22

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -9,7 +9,7 @@
 # Similar to the release image (which contains everything BUT the build
 # toolchain)
 
-FROM golang:1.21-bookworm
+FROM golang:1.22-bookworm
 
 RUN apt update && apt install -y curl ca-certificates liblz4-tool rsync socat gpg
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/go:1.21
+      - image: cimg/go:1.22
     steps:
       - checkout
       - run: go get -v -t -d ./...
@@ -32,9 +32,9 @@ jobs:
       - kubernetes/install-kubectl
       - run: |
           set -ex
-          wget https://golang.org/dl/go1.21.0.linux-amd64.tar.gz
+          wget https://golang.org/dl/go1.22.0.linux-amd64.tar.gz
           sudo rm -fR /usr/local/go
-          sudo tar -C /usr/local -xzf go1.21.0.linux-amd64.tar.gz
+          sudo tar -C /usr/local -xzf go1.22.0.linux-amd64.tar.gz
       - run: |
           set -ex
           export MINIKUBE_VERSION=v1.32.0
@@ -60,7 +60,7 @@ jobs:
 
   release-dry-run:
     docker:
-      - image: golang:1.21-bookworm
+      - image: golang:1.22-bookworm
     steps:
       - checkout
       - setup_remote_docker
@@ -93,7 +93,7 @@ jobs:
 
   release:
     docker:
-      - image: golang:1.21-bookworm
+      - image: golang:1.22-bookworm
     steps:
       - checkout
       - setup_remote_docker

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tilt-dev/ctlptl
 
-go 1.21
+go 1.22
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/test/docker-desktop/Dockerfile
+++ b/test/docker-desktop/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.20-alpine
+FROM golang:1.21-alpine
 RUN apk update && apk add bash git curl tar
 ENV CGO_ENABLED=0
 ENV KO_VERSION=0.14.1


### PR DESCRIPTION
The go releaser dry-run says that we need to use v1.22 or higher, so this bumps the version from v1.21 to v1.22

```
go: downloading github.com/goreleaser/goreleaser v1.26.1
go: github.com/goreleaser/goreleaser@latest: github.com/goreleaser/goreleaser@v1.26.1 requires go >= 1.22 (running go 1.21.10; GOTOOLCHAIN=local)

Exited with code exit status 1
```
[ [ref](https://app.circleci.com/pipelines/github/tilt-dev/ctlptl/1193/workflows/2bf235ef-247b-4280-a005-015f33e0f4eb/jobs/2846?invite=true#step-105-0_56) ]


I would opt to leave `test/*/Dockerfile` to use go v1.21 in this change as the current approach in `test/*/builder.yaml` no longer works, and is a larger piece of work. I can create a separate issue if this is acceptable.

Per the Go 1.22 release notes https://go.dev/doc/go1.22:
> `go get` is no longer supported outside of a module in the legacy `GOPATH` mode (that is, with `GO111MODULE=off`). Other build commands, such as `go build` and `go test`, will continue to work indefinitely for legacy `GOPATH` programs.

<details><summary>Further Details</summary>
<p>

Originally I tried to update those Dockerfiles, the error comes out like so:
```
...
+ kubectl logs -l app=ko-builder --all-containers
go: modules disabled by GO111MODULE=off; see 'go help modules'
+ exit 1
...
```
[ [link to circleci](https://app.circleci.com/pipelines/github/tilt-dev/ctlptl/1194/workflows/a745635a-56b6-4a2a-8cb9-d1c73d5a238a/jobs/2850?invite=true#step-107-15473_62) ]

</p>
</details> 
