### PR TITLE
kind: fix setup on HA clusters

### DIFF
--- a/pkg/cluster/admin_kind.go
+++ b/pkg/cluster/admin_kind.go
@@ -187,7 +187,19 @@ func (a *kindAdmin) applyContainerdPatchRegistryApiV2(ctx context.Context, desir
 	if err != nil {
 		return errors.Wrap(err, "configuring registry")
 	}
-	return applyContainerdPatchRegistryApiV2(ctx, a.runner, a.iostreams, nodes, desired, registry)
+	filtered := []string{}
+	for _, node := range nodes {
+		if strings.HasSuffix(node, "external-load-balancer") {
+			// Ignore the external load balancers.
+			// These load-balance traffic to the control plane nodes.
+			// They don't need registry configuration.
+			continue
+		}
+		filtered = append(filtered, node)
+	}
+
+	return applyContainerdPatchRegistryApiV2(ctx, a.runner, a.iostreams,
+		filtered, desired, registry)
 }
 
 func (a *kindAdmin) getNodes(ctx context.Context, cluster string) ([]string, error) {


### PR DESCRIPTION
when there are multiple control plane nodes,
kind creates an LB node in front of them.

before this change, we would try
to configure the registry on the LB node,
which is unnecessary and doesn't work.

fixes https://github.com/tilt-dev/ctlptl/issues/356

Signed-off-by: Nick Santos <nick.santos@docker.com>
