### PR TITLE
dd: add `?format=grouped` parameter to /app/settings

### DIFF
--- a/pkg/cluster/docker_desktop.go
+++ b/pkg/cluster/docker_desktop.go
@@ -314,7 +314,7 @@ func (c DockerDesktopClient) settings(ctx context.Context) (map[string]interface
 		{
 			client: c.backendClient,
 			method: "GET",
-			url:    "http://localhost/app/settings",
+			url:    "http://localhost/app/settings?format=grouped",
 		},
 		{
 			client: c.backendNativeClient,


### PR DESCRIPTION
DD 4.35 flattens the settings response without this.

Signed-off-by: Nick Sieger <nick@nicksieger.com>
