### PR TITLE
[feat] support passing extra args to `kind create`

### DIFF
--- a/examples/kind_extra_args.yaml
+++ b/examples/kind_extra_args.yaml
@@ -1,0 +1,14 @@
+# Creates a kind cluster with a registry.
+apiVersion: ctlptl.dev/v1alpha1
+kind: Cluster
+product: kind
+registry: ctlptl-registry
+kindExtraCreateArguments:
+# Example 1: Pass --wait to `kind create cluster` to wait for the control plane to be ready.
+- "--wait=2m"
+# Example 2: Pass --retain to `kind create cluster` to keep the containers around.
+# This is super useful for debugging cluster creation issues.
+- "--retain"
+# Example 3: Pass --verbosity=3 to `kind create cluster` to get more verbose output.
+- # This is also super useful for debugging cluster creation issues
+- "--verbosity=3"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -62,6 +62,9 @@ type Cluster struct {
 	// wins over one specified in the Kind config.
 	KindV1Alpha4Cluster *v1alpha4.Cluster `json:"kindV1Alpha4Cluster,omitempty" yaml:"kindV1Alpha4Cluster,omitempty"`
 
+	// Extra command line arguments passed to Kind create CLI. Only applicable to clusters with the product: kind.
+	KindExtraCreateArguments []string `json:"kindExtraCreateArguments,omitempty" yaml:"kindExtraCreateArguments,omitempty"`
+
 	// The Minikube cluster config. Only applicable for clusters with product: minikube.
 	Minikube *MinikubeCluster `json:"minikube,omitempty" yaml:"minikube,omitempty"`
 

--- a/pkg/cluster/admin_kind.go
+++ b/pkg/cluster/admin_kind.go
@@ -147,6 +147,7 @@ func (a *kindAdmin) Create(ctx context.Context, desired *api.Cluster, registry *
 		return errors.Wrap(err, "creating kind cluster")
 	}
 
+	args = append(args, desired.KindExtraCreateArguments...)
 	args = append(args, "--config", "-")
 
 	iostreams := a.iostreams


### PR DESCRIPTION
## What does this PR do?
- Allows passing arbitrary extra arguments to `kind`. This is useful for several debugging scenarios and edge cases, described in the `kind_extra_args.yaml` file I included.