### PR TITLE
registry: improve error handling on port status

### DIFF
--- a/pkg/api/generated.deepcopy.go
+++ b/pkg/api/generated.deepcopy.go
@@ -267,6 +267,11 @@ func (in *RegistryStatus) DeepCopyInto(out *RegistryStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Warnings != nil {
+		in, out := &in.Warnings, &out.Warnings
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -245,6 +245,9 @@ type RegistryStatus struct {
 
 	// Image for the running container.
 	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+
+	// Warnings that occurred when reporting the registry status.
+	Warnings []string `json:"warnings,omitempty" yaml:"warnings,omitempty"`
 }
 
 // RegistryList is a list of Registrys.

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -304,7 +304,7 @@ func (o *GetOptions) registriesAsTable(registries []api.Registry) runtime.Object
 		}
 
 		hostAddress := "none"
-		if registry.Status.HostPort != 0 {
+		if registry.Status.ListenAddress != "" && registry.Status.HostPort != 0 {
 			hostAddress = fmt.Sprintf("%s:%d", registry.Status.ListenAddress, registry.Status.HostPort)
 		}
 


### PR DESCRIPTION
noticed while poking around on https://github.com/tilt-dev/tilt/issues/6457

i'm not sure this is actually the underlying problem
but it's good to clean up anyway.

Signed-off-by: Nick Santos <nick.santos@docker.com>
