### PR TITLE
[feat] pull-through caching/proxying for images

### DIFF
--- a/docs/ctlptl_create_registry.md
+++ b/docs/ctlptl_create_registry.md
@@ -12,6 +12,7 @@ ctlptl create registry [name] [flags]
   ctlptl create registry ctlptl-registry
   ctlptl create registry ctlptl-registry --port=5000
   ctlptl create registry ctlptl-registry --port=5000 --listen-address 0.0.0.0
+  ctlptl create registry ctlptl-pull-through-registry --proxy-remote-url=https://registry-1.docker.io
 ```
 
 ### Options
@@ -25,6 +26,15 @@ ctlptl create registry [name] [flags]
       --port int                      The port to expose the registry on host. If not specified, chooses a random port
       --show-managed-fields           If true, keep the managedFields when printing objects in JSON or YAML format.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+```
+
+### Remote proxy options
+If `--remote-proxy-url` is specified, the registry is configured as a pull-through cache:
+```
+      --proxy-remote-url string       The remote URL for the pull-through proxy
+      --proxy-username string         The username for the pull-through proxy authentication
+      --proxy-password string         The password for the pull-through proxy authentication. 
+      --proxy-ttl string              The TTL for the pull-through proxy cache
 ```
 
 ### SEE ALSO

--- a/examples/pull-through-registry.yaml
+++ b/examples/pull-through-registry.yaml
@@ -1,0 +1,25 @@
+# Creates a registry called ctlptl-registry available on 127.0.0.1:5002
+apiVersion: ctlptl.dev/v1alpha1
+kind: Registry
+name: ctlptl-registry
+port: 5002
+listenAddress: 127.0.0.1
+---
+# Creates a pull-through registry called ctlptl-pull-through-registry available on 127.0.0.1:5003
+apiVersion: ctlptl.dev/v1alpha1
+kind: Registry
+name: ctlptl-pull-through-registry
+port: 5003
+listenAddress: 127.0.0.1
+proxy:
+  remoteURL: "https://registry-1.docker.io"
+  username: "my-username"
+  password: "$MY_PASSWORD_ENV"
+---
+# Create a Kind cluster with the pull-through registry
+apiVersion: ctlptl.dev/v1alpha1
+kind: Cluster
+product: kind
+registry: ctlptl-registry
+pullThroughRegistries:
+  - ctlptl-pull-through-registry

--- a/internal/dctr/run.go
+++ b/internal/dctr/run.go
@@ -152,6 +152,7 @@ func Run(ctx context.Context, cli CLI, name string, config *container.Config, ho
 
 	id := resp.ID
 	err = c.ContainerStart(ctx, id, container.StartOptions{})
+
 	if err != nil {
 		return fmt.Errorf("starting %s: %v", name, err)
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -42,6 +42,13 @@ type Cluster struct {
 	// Not supported on all cluster products.
 	Registry string `json:"registry,omitempty" yaml:"registry,omitempty"`
 
+	// The name of pull-through registries to add to the cluster.
+	//
+	// These registries must already exist. `ctlptl` will fail if they don't.
+	//
+	// Not supported on all cluster products.
+	PullThroughRegistries []string `json:"pullThroughRegistries,omitempty" yaml:"pullThroughRegistries,omitempty"`
+
 	// The desired version of Kubernetes to run.
 	//
 	// Examples:
@@ -160,6 +167,15 @@ type ClusterList struct {
 	Items []Cluster `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
+// RegistryProxySpec describes the configuration for a pull-through registry.
+// See: https://distribution.github.io/distribution/recipes/mirror/#run-a-registry-as-a-pull-through-cache
+type RegistryProxySpec struct {
+	RemoteURL string `json:"remoteURL,omitempty" yaml:"remoteURL,omitempty"`
+	Username  string `json:"username,omitempty" yaml:"username,omitempty"`
+	Password  string `json:"password,omitempty" yaml:"password,omitempty"`
+	TTL       string `json:"ttl,omitempty" yaml:"ttl,omitempty"`
+}
+
 // Cluster contains registry configuration.
 //
 // Currently designed for local registries on the host machine, but
@@ -200,6 +216,10 @@ type Registry struct {
 	//
 	// Defaults to `docker.io/library/registry:2`.
 	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+
+	// Proxy configuration for a pull-through registry.
+	// If provided, the registry will be configured as a pull-through registry.
+	Proxy *RegistryProxySpec `json:"proxy,omitempty" yaml:"proxy,omitempty"`
 
 	// Most recently observed status of the registry.
 	// Populated by the system.

--- a/pkg/cluster/admin.go
+++ b/pkg/cluster/admin.go
@@ -18,7 +18,7 @@ type Admin interface {
 	//
 	// Make a best effort attempt to delete any resources that might block creation
 	// of the cluster.
-	Create(ctx context.Context, desired *api.Cluster, registry *api.Registry) error
+	Create(ctx context.Context, desired *api.Cluster, registry *api.Registry, pullThroughRegistries []*api.Registry) error
 
 	// Infers the LocalRegistryHosting that this admin will try to configure.
 	LocalRegistryHosting(ctx context.Context, desired *api.Cluster, registry *api.Registry) (*localregistry.LocalRegistryHostingV1, error)

--- a/pkg/cluster/admin_docker_desktop.go
+++ b/pkg/cluster/admin_docker_desktop.go
@@ -23,9 +23,12 @@ func newDockerDesktopAdmin(host string, os string, d4m d4mClient) *dockerDesktop
 }
 
 func (a *dockerDesktopAdmin) EnsureInstalled(ctx context.Context) error { return nil }
-func (a *dockerDesktopAdmin) Create(ctx context.Context, desired *api.Cluster, registry *api.Registry) error {
+func (a *dockerDesktopAdmin) Create(ctx context.Context, desired *api.Cluster, registry *api.Registry, pullThroughRegistries []*api.Registry) error {
 	if registry != nil {
 		return fmt.Errorf("ctlptl currently does not support connecting a registry to docker-desktop")
+	}
+	if len(pullThroughRegistries) > 0 {
+		return fmt.Errorf("ctlptl currently does not support connecting pull-through registries to docker-desktop")
 	}
 
 	isLocalDockerDesktop := docker.IsLocalDockerDesktop(a.host, a.os)

--- a/pkg/cluster/admin_k3d.go
+++ b/pkg/cluster/admin_k3d.go
@@ -48,10 +48,13 @@ func (a *k3dAdmin) EnsureInstalled(ctx context.Context) error {
 	return nil
 }
 
-func (a *k3dAdmin) Create(ctx context.Context, desired *api.Cluster, registry *api.Registry) error {
+func (a *k3dAdmin) Create(ctx context.Context, desired *api.Cluster, registry *api.Registry, pullThroughRegistries []*api.Registry) error {
 	klog.V(3).Infof("Creating cluster with config:\n%+v\n---\n", desired)
 	if registry != nil {
 		klog.V(3).Infof("Initializing cluster with registry config:\n%+v\n---\n", registry)
+	}
+	if len(pullThroughRegistries) > 0 {
+		return fmt.Errorf("ctlptl currently does not support connecting pull-through registries to docker-desktop")
 	}
 
 	k3dV, err := a.version(ctx)

--- a/pkg/cluster/admin_k3d_test.go
+++ b/pkg/cluster/admin_k3d_test.go
@@ -27,7 +27,7 @@ func TestK3DStartFlagsV4(t *testing.T) {
 
 	err = f.a.Create(ctx, &api.Cluster{
 		Name: "k3d-my-cluster",
-	}, &api.Registry{Name: "my-reg"})
+	}, &api.Registry{Name: "my-reg"}, []*api.Registry{})
 	assert.NoError(t, err)
 	assert.Equal(t, []string{
 		"k3d", "cluster", "create", "my-cluster",
@@ -50,7 +50,7 @@ func TestK3DStartFlagsV5(t *testing.T) {
 				Network: "bar",
 			},
 		},
-	}, &api.Registry{Name: "my-reg"})
+	}, &api.Registry{Name: "my-reg"}, []*api.Registry{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"k3d", "cluster", "create", "my-cluster",
@@ -82,7 +82,7 @@ func TestK3DV1alpha5File(t *testing.T) {
 				Network: "bar",
 			},
 		},
-	}, &api.Registry{Name: "my-reg"})
+	}, &api.Registry{Name: "my-reg"}, []*api.Registry{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"k3d", "cluster", "create", "my-cluster",
@@ -106,7 +106,7 @@ func TestK3DV1alpha4FileOnOldVersions(t *testing.T) {
 	ctx := context.Background()
 	err := f.a.Create(ctx, &api.Cluster{
 		Name: "k3d-my-cluster",
-	}, &api.Registry{Name: "my-reg"})
+	}, &api.Registry{Name: "my-reg"}, []*api.Registry{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"k3d", "cluster", "create", "my-cluster",

--- a/pkg/cluster/admin_minikube.go
+++ b/pkg/cluster/admin_minikube.go
@@ -78,10 +78,13 @@ func (a *minikubeAdmin) version(ctx context.Context) (semver.Version, error) {
 	return result, nil
 }
 
-func (a *minikubeAdmin) Create(ctx context.Context, desired *api.Cluster, registry *api.Registry) error {
+func (a *minikubeAdmin) Create(ctx context.Context, desired *api.Cluster, registry *api.Registry, pullThroughRegistries []*api.Registry) error {
 	klog.V(3).Infof("Creating cluster with config:\n%+v\n---\n", desired)
 	if registry != nil {
 		klog.V(3).Infof("Initializing cluster with registry config:\n%+v\n---\n", registry)
+	}
+	if len(pullThroughRegistries) > 0 {
+		return fmt.Errorf("ctlptl currently does not support connecting pull-through registries to docker-desktop")
 	}
 
 	v, err := a.version(ctx)

--- a/pkg/cluster/admin_minikube_test.go
+++ b/pkg/cluster/admin_minikube_test.go
@@ -16,7 +16,7 @@ import (
 func TestMinikubeStartFlags(t *testing.T) {
 	f := newMinikubeFixture()
 	ctx := context.Background()
-	err := f.a.Create(ctx, &api.Cluster{Name: "minikube", Minikube: &api.MinikubeCluster{StartFlags: []string{"--foo"}}}, nil)
+	err := f.a.Create(ctx, &api.Cluster{Name: "minikube", Minikube: &api.MinikubeCluster{StartFlags: []string{"--foo"}}}, nil, []*api.Registry{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"minikube", "start",

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -731,7 +731,7 @@ func newFakeAdmin(config *clientcmdapi.Config, fakeK8s *fake.Clientset) *fakeAdm
 
 func (a *fakeAdmin) EnsureInstalled(ctx context.Context) error { return nil }
 
-func (a *fakeAdmin) Create(ctx context.Context, config *api.Cluster, registry *api.Registry) error {
+func (a *fakeAdmin) Create(ctx context.Context, config *api.Cluster, registry *api.Registry, registries []*api.Registry) error {
 	a.created = config.DeepCopy()
 	a.createdRegistry = registry.DeepCopy()
 	a.config.Contexts[config.Name] = &clientcmdapi.Context{Cluster: config.Name}


### PR DESCRIPTION
## Background
- Motivation: https://github.com/tilt-dev/ctlptl/issues/355
- In my "real" Kubernetes clusters, I use ECR as an image registry. Nodes are automatically authorized/configured to pull from ECR through a combination of IAM and containerd settings.
- I want my Tilt Kubernetes clusters to mirror "real" clusters as much as possible. I want to avoid making Tilt-specific modifications to Kubernetes manifests to make them work (see discussion in https://github.com/tilt-dev/ctlptl/issues/355).
- There currently isn't a way to achieve both of these goals simulaneously:
   - I _could_ use some combination of `docker pull && docker push` or  `kind load`, though this makes the Tilt configuration clunky.
   - I _could_ provide `imagePullSecrets`, but this causes the Tilt configuration to deviate from the "real" configuration (and would require modifying hundreds of helm charts).
 
 - **Note:** I think there are other, similar usecases for providing cluster authentication credentials. For example, a user might want to avoid Docker registry ratelimits by providing a user token.

## What does this PR do?
- This PR adds the ability for a user to configure pull-through proxy/cache registries, which are attached to the `kind` cluster (possible in other cluster provisioners, but I have chosen this as a starting point).
- Authentication can be passed to the proxy via the `username` and `password` properties, or via a templated env var to `password.`
