### PR TITLE
[feat] pull-through caching/proxying for images

### DIFF
--- a/examples/kind_registry_auth.yaml
+++ b/examples/kind_registry_auth.yaml
@@ -1,0 +1,15 @@
+# Creates a kind cluster with Kind's custom cluster config
+#
+apiVersion: ctlptl.dev/v1alpha1
+kind: Cluster
+product: kind
+registry: ctlptl-registry
+registryAuths:
+- host: docker.io
+  endpoint: https://registry-1.docker.io
+  username: <docker hub username>
+  password: <docker hub token>
+kindV1Alpha4Cluster:
+  name: my-cluster
+  nodes:
+  - role: control-plane

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -16,6 +16,17 @@ type TypeMeta struct {
 	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
 }
 
+// PullThroughRegistry contains configuration for pull-through registries
+type PullThroughRegistry struct {
+	// The FQDN of the registry (i.e. docker.io)
+	RegistryFQDN string `json:"registryFQDN,omitempty" yaml:"registryFQDN,omitempty"`
+    
+	// The RemoteURL of the registry (i.e. https://registry-1.docker.io)
+	RemoteURL string `json:"remoteURL,omitempty" yaml:"remoteURL,omitempty"`
+	Username string `json:"username,omitempty" yaml:"username,omitempty"`
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+}
+
 // Cluster contains cluster configuration.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type Cluster struct {
@@ -41,6 +52,11 @@ type Cluster struct {
 	//
 	// Not supported on all cluster products.
 	Registry string `json:"registry,omitempty" yaml:"registry,omitempty"`
+
+	// A list of pull-through registries to configure on the cluster.
+	//
+	// Not supported on all cluster products.
+	PullThroughRegistries []PullThroughRegistry `json:"pullThroughRegistries,omitempty" yaml:"pullThroughRegistries,omitempty"`
 
 	// The desired version of Kubernetes to run.
 	//

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -16,13 +16,13 @@ type TypeMeta struct {
 	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
 }
 
-// PullThroughRegistry contains configuration for pull-through registries
-type PullThroughRegistry struct {
+// RegistryAuth contains configuration for pull-through registries
+type RegistryAuth struct {
 	// The FQDN of the registry (i.e. docker.io)
-	RegistryFQDN string `json:"registryFQDN,omitempty" yaml:"registryFQDN,omitempty"`
-    
-	// The RemoteURL of the registry (i.e. https://registry-1.docker.io)
-	RemoteURL string `json:"remoteURL,omitempty" yaml:"remoteURL,omitempty"`
+	Host string `json:"host,omitempty" yaml:"host,omitempty"`
+
+	// The Endpoint of the registry (i.e. https://registry-1.docker.io)
+	Endpoint string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 	Username string `json:"username,omitempty" yaml:"username,omitempty"`
 	Password string `json:"password,omitempty" yaml:"password,omitempty"`
 }
@@ -56,7 +56,7 @@ type Cluster struct {
 	// A list of pull-through registries to configure on the cluster.
 	//
 	// Not supported on all cluster products.
-	PullThroughRegistries []PullThroughRegistry `json:"pullThroughRegistries,omitempty" yaml:"pullThroughRegistries,omitempty"`
+	RegistryAuths []RegistryAuth `json:"registryAuths,omitempty" yaml:"registryAuths,omitempty"`
 
 	// The desired version of Kubernetes to run.
 	//

--- a/pkg/cluster/admin_docker_desktop.go
+++ b/pkg/cluster/admin_docker_desktop.go
@@ -27,7 +27,7 @@ func (a *dockerDesktopAdmin) Create(ctx context.Context, desired *api.Cluster, r
 	if registry != nil {
 		return fmt.Errorf("ctlptl currently does not support connecting a registry to docker-desktop")
 	}
-	if len(desired.PullThroughRegistries) > 0 {
+	if len(desired.RegistryAuths) > 0 {
 		return fmt.Errorf("ctlptl currently does not support connecting pull-through registries to docker-desktop")
 	}
 

--- a/pkg/cluster/admin_docker_desktop.go
+++ b/pkg/cluster/admin_docker_desktop.go
@@ -27,6 +27,9 @@ func (a *dockerDesktopAdmin) Create(ctx context.Context, desired *api.Cluster, r
 	if registry != nil {
 		return fmt.Errorf("ctlptl currently does not support connecting a registry to docker-desktop")
 	}
+	if len(desired.PullThroughRegistries) > 0 {
+		return fmt.Errorf("ctlptl currently does not support connecting pull-through registries to docker-desktop")
+	}
 
 	isLocalDockerDesktop := docker.IsLocalDockerDesktop(a.host, a.os)
 	if !isLocalDockerDesktop {

--- a/pkg/cluster/admin_k3d.go
+++ b/pkg/cluster/admin_k3d.go
@@ -53,6 +53,9 @@ func (a *k3dAdmin) Create(ctx context.Context, desired *api.Cluster, registry *a
 	if registry != nil {
 		klog.V(3).Infof("Initializing cluster with registry config:\n%+v\n---\n", registry)
 	}
+	if len(desired.PullThroughRegistries) > 0 {
+		return fmt.Errorf("ctlptl currently does not support connecting pull-through registries to k3d")
+	}
 
 	k3dV, err := a.version(ctx)
 	if err != nil {

--- a/pkg/cluster/admin_k3d.go
+++ b/pkg/cluster/admin_k3d.go
@@ -53,7 +53,7 @@ func (a *k3dAdmin) Create(ctx context.Context, desired *api.Cluster, registry *a
 	if registry != nil {
 		klog.V(3).Infof("Initializing cluster with registry config:\n%+v\n---\n", registry)
 	}
-	if len(desired.PullThroughRegistries) > 0 {
+	if len(desired.RegistryAuths) > 0 {
 		return fmt.Errorf("ctlptl currently does not support connecting pull-through registries to k3d")
 	}
 

--- a/pkg/cluster/admin_kind.go
+++ b/pkg/cluster/admin_kind.go
@@ -90,7 +90,7 @@ func (a *kindAdmin) kindClusterConfig(desired *api.Cluster, registry *api.Regist
 		// Parse the endpoint
 		parsedEndpoint, err := url.Parse(reg.Endpoint)
 		if err != nil {
-			klog.Warningf("Failed to parse registry URL %s: %v", reg.Endpoint)
+			klog.Warningf("Failed to parse registry URL %s: %v", reg.Endpoint, err)
 			continue
 		}
 

--- a/pkg/cluster/admin_kind.go
+++ b/pkg/cluster/admin_kind.go
@@ -57,7 +57,7 @@ func (a *kindAdmin) EnsureInstalled(ctx context.Context) error {
 	return nil
 }
 
-func (a *kindAdmin) kindClusterConfig(desired *api.Cluster, registry *api.Registry, registryAPI containerdRegistryAPI) *v1alpha4.Cluster {
+func (a *kindAdmin) kindClusterConfig(desired *api.Cluster, registry *api.Registry, registryAPI containerdRegistryAPI) (*v1alpha4.Cluster, error) {
 	kindConfig := desired.KindV1Alpha4Cluster
 	if kindConfig == nil {
 		kindConfig = &v1alpha4.Cluster{}
@@ -90,8 +90,7 @@ func (a *kindAdmin) kindClusterConfig(desired *api.Cluster, registry *api.Regist
 		// Parse the endpoint
 		parsedEndpoint, err := url.Parse(reg.Endpoint)
 		if err != nil {
-			klog.Warningf("Failed to parse registry URL %s: %v", reg.Endpoint, err)
-			continue
+			return nil, errors.Wrapf(err, "Error parsing registry endpoint: %s", reg.Endpoint)
 		}
 
 		// Add the registry to the list of mirrors.
@@ -113,7 +112,7 @@ func (a *kindAdmin) kindClusterConfig(desired *api.Cluster, registry *api.Regist
 		}
 	}
 
-	return kindConfig
+	return kindConfig, nil
 }
 
 func (a *kindAdmin) Create(ctx context.Context, desired *api.Cluster, registry *api.Registry) error {
@@ -168,7 +167,11 @@ func (a *kindAdmin) Create(ctx context.Context, desired *api.Cluster, registry *
 		args = append(args, "--image", node)
 	}
 
-	kindConfig := a.kindClusterConfig(desired, registry, registryAPI)
+	kindConfig, err := a.kindClusterConfig(desired, registry, registryAPI)
+	if err != nil {
+		return errors.Wrap(err, "generating kind config")
+	}
+
 	buf := bytes.NewBuffer(nil)
 	encoder := yaml.NewEncoder(buf)
 	err = encoder.Encode(kindConfig)
@@ -196,7 +199,7 @@ func (a *kindAdmin) Create(ctx context.Context, desired *api.Cluster, registry *
 			}
 		}
 
-		if registryAPI == containerdRegistryV2 {
+		if registryAPI == containerdRegistryV2 && len(desired.RegistryAuths) == 0 {
 			err = a.applyContainerdPatchRegistryApiV2(ctx, desired, registry)
 			if err != nil {
 				return err

--- a/pkg/cluster/admin_kind_test.go
+++ b/pkg/cluster/admin_kind_test.go
@@ -105,7 +105,8 @@ func TestKindClusterConfigWithPullThroughRegistries(t *testing.T) {
 		},
 	}
 
-	kindConfig := a.kindClusterConfig(desired, nil, containerdRegistryV2)
+	kindConfig, err := a.kindClusterConfig(desired, nil, containerdRegistryV2)
+	assert.NoError(t, err)
 
 	expectedMirror := `[plugins."io.containerd.grpc.v1.cri".registry.mirrors."example.com"]
   endpoint = ["http://example.com:5000"]

--- a/pkg/cluster/admin_kind_test.go
+++ b/pkg/cluster/admin_kind_test.go
@@ -98,7 +98,7 @@ func TestKindClusterConfigWithPullThroughRegistries(t *testing.T) {
 		RegistryAuths: []api.RegistryAuth{
 			{
 				Host:     "example.com",
-				Endpoint: "example.com:5000",
+				Endpoint: "http://example.com:5000",
 				Username: "user",
 				Password: "pass",
 			},
@@ -110,7 +110,7 @@ func TestKindClusterConfigWithPullThroughRegistries(t *testing.T) {
 	expectedMirror := `[plugins."io.containerd.grpc.v1.cri".registry.mirrors."example.com"]
   endpoint = ["http://example.com:5000"]
 `
-	expectedAuth := `[plugins."io.containerd.grpc.v1.cri".registry.configs."example.com".auth]
+	expectedAuth := `[plugins."io.containerd.grpc.v1.cri".registry.configs."example.com:5000".auth]
   username = "user"
   password = "pass"
 `

--- a/pkg/cluster/admin_kind_test.go
+++ b/pkg/cluster/admin_kind_test.go
@@ -95,12 +95,12 @@ func TestKindClusterConfigWithPullThroughRegistries(t *testing.T) {
 	a := newKindAdmin(iostreams, runner, &fakeDockerClient{})
 
 	desired := &api.Cluster{
-		PullThroughRegistries: []api.PullThroughRegistry{
+		RegistryAuths: []api.RegistryAuth{
 			{
-				RegistryFQDN: "example.com",
-				RemoteURL:    "example.com:5000",
-				Username:     "user",
-				Password:     "pass",
+				Host:     "example.com",
+				Endpoint: "example.com:5000",
+				Username: "user",
+				Password: "pass",
 			},
 		},
 	}

--- a/pkg/cluster/admin_minikube.go
+++ b/pkg/cluster/admin_minikube.go
@@ -83,6 +83,9 @@ func (a *minikubeAdmin) Create(ctx context.Context, desired *api.Cluster, regist
 	if registry != nil {
 		klog.V(3).Infof("Initializing cluster with registry config:\n%+v\n---\n", registry)
 	}
+	if len(desired.PullThroughRegistries) > 0 {
+		return fmt.Errorf("ctlptl currently does not support connecting pull-through registries to minikube")
+	}
 
 	v, err := a.version(ctx)
 	if err != nil {

--- a/pkg/cluster/admin_minikube.go
+++ b/pkg/cluster/admin_minikube.go
@@ -83,7 +83,7 @@ func (a *minikubeAdmin) Create(ctx context.Context, desired *api.Cluster, regist
 	if registry != nil {
 		klog.V(3).Infof("Initializing cluster with registry config:\n%+v\n---\n", registry)
 	}
-	if len(desired.PullThroughRegistries) > 0 {
+	if len(desired.RegistryAuths) > 0 {
 		return fmt.Errorf("ctlptl currently does not support connecting pull-through registries to minikube")
 	}
 


### PR DESCRIPTION
## Background
- Motivation: https://github.com/tilt-dev/ctlptl/issues/355
- In my "real" Kubernetes clusters, I use ECR as an image registry. Nodes are automatically authorized/configured to pull from ECR through a combination of IAM and containerd settings.
- I want my Tilt Kubernetes clusters to mirror "real" clusters as much as possible. I want to avoid making Tilt-specific modifications to Kubernetes manifests to make them work (see discussion in https://github.com/tilt-dev/ctlptl/issues/355).
- There currently isn't a way to achieve both of these goals simulaneously:
   - I _could_ use some combination of `docker pull && docker push` or  `kind load`, though this makes the Tilt configuration clunky.
   - I _could_ provide `imagePullSecrets`, but this causes the Tilt configuration to deviate from the "real" configuration (and would require modifying hundreds of helm charts).
 
 - **Note:** I think there are other, similar usecases for providing cluster authentication credentials. For example, a user might want to avoid Docker registry ratelimits by providing a user token.

## What does this PR do?
- This PR adds the ability for a user to configure pull-through proxy/cache registries, which are attached to the `kind` cluster (possible in other cluster provisioners, but I have chosen this as a starting point).
- Authentication can be passed to the proxy via the `username` and `password` properties, or via a templated env var to `password.`

## Test Plan
- I created a cluster using a Docker Hub endpoint, passing in my `username` and `password` (token).
- I was successfully able to start docker containers with an image contained in a private repo.