### PR TITLE
registry: strip desktop labels

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -384,6 +384,18 @@ func (c *Controller) labelConfigs(existing *api.Registry, desired *api.Registry)
 		newLabels[k] = v
 	}
 
+	// Workaround for a Docker desktop bug where the labels
+	// affect networking behavior, and break the explicit networking settings.
+	// https://github.com/docker/desktop-feedback/issues/276
+	//
+	// We want to make sure these magic labels aren't
+	// copied from the existing container.
+	for k := range newLabels {
+		if strings.HasPrefix(k, "desktop.docker.io") {
+			delete(newLabels, k)
+		}
+	}
+
 	return newLabels
 }
 

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -314,6 +314,30 @@ func TestApplyLabels(t *testing.T) {
 	}
 }
 
+func TestStripDesktopLabels(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	// Make sure the previous registry is wiped out
+	// because it doesn't have the labels we want.
+	f.docker.containers = []container.Summary{kindRegistry()}
+
+	registry, err := f.c.Apply(context.Background(), &api.Registry{
+		TypeMeta: typeMeta,
+		Name:     "kind-registry",
+		Labels:   map[string]string{"desktop.docker.io/label": "should-be-stripped"},
+	})
+	if assert.NoError(t, err) {
+		assert.Equal(t, "running", registry.Status.State)
+	}
+	config := f.docker.lastCreateConfig
+	if assert.NotNil(t, config) {
+		assert.Equal(t, map[string]string{
+			"dev.tilt.ctlptl.role": "registry",
+		}, config.Labels)
+	}
+}
+
 func TestPreservePort(t *testing.T) {
 	f := newFixture(t)
 	defer f.TearDown()


### PR DESCRIPTION
if these labels are copied from an existing
container, they can cause container networking
to break in weird ways

Signed-off-by: Nick Santos <nicholas.j.santos@gmail.com>
