### PR TITLE
release: only release to tiltdev docker hub namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           only_for_branches: main
   e2e-remote-docker:
     docker:
-      - image: "docker/tilt-ctlptl-ci@sha256:5616dcc986f2bac09a4c2f8f3b9f95b0480de947fc3816da7ea94046410ff2c8"
+      - image: "tiltdev/ctlptl-ci@sha256:e3aa0b3666645820821254b06dbaf6def4fe8dca7c3418aa032440e89167c1ae"
     steps:
       - checkout
       - setup_remote_docker

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,7 @@ brews:
     name: homebrew-tap
   commit_author:
     name: Tilt Dev
-    email: hi@tilt.dev
+    email: tilt-team@docker.com
   url_template: "https://github.com/tilt-dev/ctlptl/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   homepage: "https://ctlptl.dev/"
   description: "Making local Kubernetes clusters easy to set up and tear down"
@@ -75,7 +75,7 @@ scoops:
     name: scoop-bucket
   commit_author:
     name: Tilt Dev
-    email: hi@tilt.dev
+    email: tilt-team@docker.com
   commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
   homepage: "https://ctlptl.dev/"
   description: "Making local Kubernetes clusters easy to set up and tear down"
@@ -85,7 +85,6 @@ dockers:
   goarch: amd64
   image_templates:
     - "tiltdev/ctlptl:{{ .Tag }}-amd64"
-    - "docker/tilt-ctlptl:{{ .Tag }}-amd64"
   dockerfile: hack/Dockerfile
   use: buildx
   build_flag_templates:
@@ -103,7 +102,6 @@ dockers:
   goarm: ''
   image_templates:
     - "tiltdev/ctlptl:{{ .Tag }}-arm64"
-    - "docker/tilt-ctlptl:{{ .Tag }}-arm64"
   dockerfile: hack/Dockerfile
   use: buildx
   build_flag_templates:
@@ -125,14 +123,6 @@ docker_manifests:
   image_templates:
   - tiltdev/{{ .ProjectName }}:{{ .Tag }}-amd64
   - tiltdev/{{ .ProjectName }}:{{ .Tag }}-arm64
-- name_template: docker/tilt-{{ .ProjectName }}:{{ .Tag }}
-  image_templates:
-  - docker/tilt-{{ .ProjectName }}:{{ .Tag }}-amd64
-  - docker/tilt-{{ .ProjectName }}:{{ .Tag }}-arm64
-- name_template: docker/tilt-{{ .ProjectName }}:latest
-  image_templates:
-  - docker/tilt-{{ .ProjectName }}:{{ .Tag }}-amd64
-  - docker/tilt-{{ .ProjectName }}:{{ .Tag }}-arm64
 
 
 # Uncomment these lines if you want to experiment with other

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -65,7 +65,7 @@ We do not believe that all conflict is bad; healthy debate and disagreement ofte
 
 If you see someone violating the Code of Conduct, you are encouraged to address the behavior directly with those involved. Many issues can be resolved quickly and easily, and this gives people more control over the outcome of their dispute. If you are unable to resolve the matter for any reason, or if the behavior is threatening or harassing, report it. We are dedicated to providing an environment where participants feel welcome and safe.
 
-Reports should be directed to **conduct@tilt.dev**.
+Reports should be directed to **tilt-team@docker.com**.
 
 We will investigate every complaint, but you may not receive a direct response. We will use our discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from the project and project-sponsored spaces. We will notify the accused of the report and provide them an opportunity to discuss it before any action is taken. The identity of the reporter will be omitted from the details of the report supplied to the accused. In potentially harmful situations, such as ongoing harassment or threats to anyone’s safety, we may take action without notice.
 

--- a/hack/publish-ci-image.sh
+++ b/hack/publish-ci-image.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 BUILDER=buildx-multiarch
-IMAGE_NAME=docker/tilt-ctlptl-ci
+IMAGE_NAME=tiltdev/ctlptl-ci
 
 docker buildx inspect $BUILDER || docker buildx create --name=$BUILDER --driver=docker-container --driver-opt=network=host
 docker buildx build --builder=$BUILDER --pull --platform=linux/amd64,linux/arm64 --push -t "$IMAGE_NAME" -f .circleci/Dockerfile .

--- a/hack/release-update-docs.sh
+++ b/hack/release-update-docs.sh
@@ -33,7 +33,7 @@ sed -i -E "s/CTLPTL_VERSION=\".*\"/CTLPTL_VERSION=\"$VERSION\"/" INSTALL.md
 sed -i -E "s/CTLPTL_VERSION = \".*\"/CTLPTL_VERSION = \"$VERSION\"/" INSTALL.md
 go run ./cmd/ctlptl docs ./docs
 git add .
-git config --global user.email "it@tilt.dev"
+git config --global user.email "tilt-team@docker.com"
 git config --global user.name "Tilt Dev"
 git commit -a -m "Update version numbers: $VERSION"
 git push origin main


### PR DESCRIPTION
docker hub auth is moving towards systems
where auth is scoped by org (e.g., OATs).

this makes it hard to publish to two orgs
at once (docker and tiltdev).

i think the simpler solution is to keep the tiltdev
images in their own org rather than mixing them
with the docker org

Signed-off-by: Nick Santos <nick.santos@docker.com>
