### PR TITLE
registry: only compare the env vars the spec asks for

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
-	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -258,8 +257,14 @@ func (c *Controller) Apply(ctx context.Context, desired *api.Registry) (*api.Reg
 		desiredEnvs["REGISTRY_STORAGE_DELETE_ENABLED"] = "true"
 		desired.Env = append(desired.Env, "REGISTRY_STORAGE_DELETE_ENABLED=true")
 	}
-	if eq := reflect.DeepEqual(desiredEnvs, existingEnvs); !eq {
-		needsDelete = true
+	// Only the env vars the spec asks for take part in the comparison. The
+	// container's env also carries whatever the image bakes in (registry:3
+	// sets OTEL_TRACES_EXPORTER=none), and a bare spec must keep matching a
+	// container it created from that image. Same rule as for labels above.
+	for key, value := range desiredEnvs {
+		if existingEnvs[key] != value {
+			needsDelete = true
+		}
 	}
 
 	if needsDelete && existing.Name != "" {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -455,6 +455,30 @@ func TestCustomEnv(t *testing.T) {
 	}
 }
 
+func TestApplyIgnoresEnvBakedIntoTheImage(t *testing.T) {
+	f := newFixture(t)
+	defer f.TearDown()
+
+	// registry:3 sets OTEL_TRACES_EXPORTER=none in its image config, so the
+	// container's env carries a variable nobody asked ctlptl for. A bare spec
+	// must still match the container it created from that image.
+	f.docker.containers = []container.Summary{kindRegistry()}
+	f.docker.containerEnv = []string{
+		"REGISTRY_STORAGE_DELETE_ENABLED=true",
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"OTEL_TRACES_EXPORTER=none",
+	}
+
+	registry, err := f.c.Apply(context.Background(), &api.Registry{
+		TypeMeta: typeMeta,
+		Name:     "kind-registry",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, kindRegistry().ID, registry.Status.ContainerID)
+	assert.Equal(t, "", f.docker.lastRemovedContainer, "Registry should not have been deleted")
+	assert.Nil(t, f.docker.lastCreateConfig, "Registry should not have been re-created")
+}
+
 type fakeCLI struct {
 	client *fakeDocker
 }
@@ -472,6 +496,10 @@ type fakeDocker struct {
 	lastRemovedContainer string
 	lastCreateConfig     *container.Config
 	lastCreateHostConfig *container.HostConfig
+
+	// Env reported by ContainerInspect for every container; nil means the
+	// env of a registry created from a bare spec.
+	containerEnv []string
 }
 
 type objectNotFoundError struct {
@@ -490,6 +518,10 @@ func (d *fakeDocker) DaemonHost() string {
 }
 
 func (d *fakeDocker) ContainerInspect(ctx context.Context, containerID string, options client.ContainerInspectOptions) (client.ContainerInspectResult, error) {
+	env := d.containerEnv
+	if env == nil {
+		env = []string{"REGISTRY_STORAGE_DELETE_ENABLED=true", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
+	}
 	for _, c := range d.containers {
 		if c.ID == containerID {
 			return client.ContainerInspectResult{
@@ -508,7 +540,7 @@ func (d *fakeDocker) ContainerInspect(ctx context.Context, containerID string, o
 						Tty:         false,
 						OpenStdin:   false,
 						StdinOnce:   false,
-						Env:         []string{"REGISTRY_STORAGE_DELETE_ENABLED=true", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+						Env:         env,
 						Cmd:         []string{"serve", "/etc/distribution/config.yml"},
 						Healthcheck: (*container.HealthConfig)(nil),
 						ArgsEscaped: false,


### PR DESCRIPTION
Fixes #424

## Problem

`Controller.Apply` compared the registry container's whole env (minus `PATH`) with the spec using `reflect.DeepEqual`. Since `registry:3` became the default image (#414) that comparison never matches: the image bakes `OTEL_TRACES_EXPORTER=none` into its config, so a bare spec is always "different", and `Apply` force-removes and recreates the registry on every `ctlptl apply`. The Cluster document always re-applies its registry with a bare spec, so declaring the variable in the Registry document does not help either. Against an existing kind cluster the recreated registry is no longer attached to the `kind` network (that only happens in the cluster-create path), and image pulls inside the node fail. Details and a reproduction in #424.

## Change

Compare only the env vars the spec asks for: every desired `KEY=value` must be present on the container, extra variables on the container are ignored. That is the rule `Labels` already follow a few lines above. `REGISTRY_STORAGE_DELETE_ENABLED=true` is still added to the desired set, so a container created without it is still recreated, and `TestCustomEnv` still covers a changed value.

Behavior change to be aware of: removing an env var from the spec no longer forces a recreate (same as labels today). If you would rather keep that, the alternative is to subtract the image's `Config.Env` (one `ImageInspect`) from the container env before comparing. Happy to switch.

## Testing

- `TestApplyIgnoresEnvBakedIntoTheImage`: a running registry whose container env carries `OTEL_TRACES_EXPORTER=none` is left alone by a bare spec (no delete, no create). The fake docker client gained a `containerEnv` override for this.
- `go test ./...`, `go vet`, `gofmt`/`goimports` clean.
- Built this branch and ran it against a throwaway kind cluster + `registry:3` registry (macOS, Colima, kind v0.33.0): three consecutive `ctlptl apply` runs of a Registry + Cluster spec produce one `Creating registry` and the container id never changes. The v0.9.5 binary against the same container recreates it on every apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
