### PR TITLE
test: add idempotence tests to the e2e tests

### DIFF
--- a/test/docker-desktop/e2e.sh
+++ b/test/docker-desktop/e2e.sh
@@ -8,8 +8,14 @@ set -exo pipefail
 export DOCKER_BUILDKIT="1"
 
 cd $(dirname $(realpath $0))
-CLUSTER_NAME="kind-ctlptl-test-cluster"
+CLUSTER_NAME="docker-desktop"
 ctlptl apply -f cluster.yaml
+
+# Idempotence check
+source ../idempotence.sh
+CLUSTER_ID=$(cluster_id "$CLUSTER_NAME")
+ctlptl apply -f cluster.yaml
+assert_unchanged "cluster $CLUSTER_NAME" "$CLUSTER_ID" "$(cluster_id "$CLUSTER_NAME")"
 
 # The ko-builder runs in an image tagged with the host as visible from the local machine.
 docker buildx build --load -t ko-builder .

--- a/test/idempotence.sh
+++ b/test/idempotence.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Helpers for checking that `ctlptl apply` is idempotent.
+#
+# Usage:
+#   REGISTRY_ID=$(registry_id ctlptl-test-registry)
+#   ctlptl apply -f registry.yaml
+#   assert_unchanged "registry" "$REGISTRY_ID" "$(registry_id ctlptl-test-registry)"
+
+# The container backing a registry. Changes if the registry is recreated.
+registry_id() {
+    ctlptl get registry "$1" -o template --template '{{.status.containerId}}'
+}
+
+# The creation time of a cluster's oldest node. Changes if the cluster is recreated.
+cluster_id() {
+    ctlptl get cluster "$1" -o template --template '{{.status.creationTimestamp}}'
+}
+
+# assert_unchanged DESCRIPTION BEFORE AFTER
+assert_unchanged() {
+    local desc="$1"
+    local before="$2"
+    local after="$3"
+
+    if [[ "$before" == "" ]]; then
+        echo "could not read the identity of $desc before re-applying"
+        exit 1
+    fi
+
+    if [[ "$before" != "$after" ]]; then
+        echo "$desc was recreated by a second 'ctlptl apply' (before: $before, after: $after)"
+        exit 1
+    fi
+}

--- a/test/k3d/e2e.sh
+++ b/test/k3d/e2e.sh
@@ -9,8 +9,18 @@ export DOCKER_BUILDKIT="1"
 
 cd $(dirname $(realpath $0))
 CLUSTER_NAME="k3d-ctlptl-test-cluster"
+REGISTRY_NAME="ctlptl-test-registry"
 ctlptl apply -f registry.yaml
 ctlptl apply -f cluster.yaml
+
+# Idempotence check
+source ../idempotence.sh
+REGISTRY_ID=$(registry_id "$REGISTRY_NAME")
+CLUSTER_ID=$(cluster_id "$CLUSTER_NAME")
+ctlptl apply -f registry.yaml
+ctlptl apply -f cluster.yaml
+assert_unchanged "registry $REGISTRY_NAME" "$REGISTRY_ID" "$(registry_id "$REGISTRY_NAME")"
+assert_unchanged "cluster $CLUSTER_NAME" "$CLUSTER_ID" "$(cluster_id "$CLUSTER_NAME")"
 
 # The ko-builder runs in an image tagged with the host as visible from the local machine.
 docker buildx build --load -t localhost:5005/ko-builder .

--- a/test/kind/e2e.sh
+++ b/test/kind/e2e.sh
@@ -9,8 +9,18 @@ export DOCKER_BUILDKIT="1"
 
 cd $(dirname $(realpath $0))
 CLUSTER_NAME="kind-ctlptl-test-cluster"
+REGISTRY_NAME="ctlptl-test-registry"
 ctlptl apply -f registry.yaml
 ctlptl apply -f cluster.yaml
+
+# Idempotence check
+source ../idempotence.sh
+REGISTRY_ID=$(registry_id "$REGISTRY_NAME")
+CLUSTER_ID=$(cluster_id "$CLUSTER_NAME")
+ctlptl apply -f registry.yaml
+ctlptl apply -f cluster.yaml
+assert_unchanged "registry $REGISTRY_NAME" "$REGISTRY_ID" "$(registry_id "$REGISTRY_NAME")"
+assert_unchanged "cluster $CLUSTER_NAME" "$CLUSTER_ID" "$(cluster_id "$CLUSTER_NAME")"
 
 # The ko-builder runs in an image tagged with the host as visible from the local machine.
 docker buildx build --load -t localhost:5005/ko-builder .

--- a/test/minikube/e2e.sh
+++ b/test/minikube/e2e.sh
@@ -9,8 +9,18 @@ export DOCKER_BUILDKIT="1"
 
 cd $(dirname $(realpath $0))
 CLUSTER_NAME="minikube-ctlptl-test-cluster"
+REGISTRY_NAME="ctlptl-test-registry"
 ctlptl apply -f registry.yaml
 ctlptl apply -f cluster.yaml
+
+# Idempotence check
+source ../idempotence.sh
+REGISTRY_ID=$(registry_id "$REGISTRY_NAME")
+CLUSTER_ID=$(cluster_id "$CLUSTER_NAME")
+ctlptl apply -f registry.yaml
+ctlptl apply -f cluster.yaml
+assert_unchanged "registry $REGISTRY_NAME" "$REGISTRY_ID" "$(registry_id "$REGISTRY_NAME")"
+assert_unchanged "cluster $CLUSTER_NAME" "$CLUSTER_ID" "$(cluster_id "$CLUSTER_NAME")"
 
 # The ko-builder runs in an image tagged with the host as visible from the local machine.
 docker buildx build --load -t localhost:5005/ko-builder .


### PR DESCRIPTION
checks to make sure applying yaml twice is a no-op

would have prevented this regression - https://github.com/tilt-dev/ctlptl/issues/424

Signed-off-by: Nick Santos <nicholas.j.santos@gmail.com>
